### PR TITLE
Update filepath name required packages

### DIFF
--- a/scripts/hail_batch/generate_pca/hgdp_1kg_pca_loadings_generate.py
+++ b/scripts/hail_batch/generate_pca/hgdp_1kg_pca_loadings_generate.py
@@ -4,10 +4,7 @@ import click
 import pandas as pd
 import hail as hl
 
-GNOMAD_HGDP_1KG_MT = (
-    'gs://gcp-public-data--gnomad/release/3.1/mt/genomes/'
-    'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
-)
+GNOMAD_HGDP_1KG_MT = 'gs://cpg-ancestry-temporary/1kg_hgdp_ld_pruning/v0/filtered_mt.mt'
 
 
 @click.command()

--- a/scripts/hail_batch/ld_prune/main.py
+++ b/scripts/hail_batch/ld_prune/main.py
@@ -21,7 +21,7 @@ dataproc.hail_dataproc_job(
     f'hgdp_1kg_ld_prune.py --output={OUTPUT}',
     max_age='5h',
     num_secondary_workers=100,
-    packages=['click'],
+    packages=['click', 'gnomad'],
     job_name='ld-prune',
 )
 


### PR DESCRIPTION
I missed the fact that ld_prune/main.py requires the 'gnomad' package in the dataproc.hail_dataproc_job function, which is now added in. I also updated the matrix table within the generate_pca/hgdp_1kg_pca_loadings_generate.py script to be the output from ld_prune.