### PR TITLE
Merge HGDP + 1KG dataset with TOB-WGS and PCA

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to perform a
 
 ```sh
 analysis-runner --dataset ancestry \
---access-level test --output-dir "gs://cpg-ancestry-temporary/1kg_hgdp_tobwgs_pca/v0" \
+--access-level test --output-dir "gs://cpg-ancestry-analysis/1kg_hgdp_tobwgs_pca/v0" \
 --description "hgdp1kg tobwgs pca" main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/README.md
@@ -1,0 +1,9 @@
+# Perform a pca on the combined HGDP + 1KG and TOB-WGS data
+
+This runs a Hail query script in Dataproc using Hail Batch in order to perform a pca on the 1KG + HGDP + TOB-WGS dataset. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset ancestry \
+--access-level test --output-dir "gs://cpg-ancestry-temporary/1kg_hgdp_tobwgs_pca/v0" \
+--description "hgdp1kg tobwgs pca" main.py
+```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
@@ -10,7 +10,7 @@ GNOMAD_HGDP_1KG_MT = (
     'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
 )
 
-TOB_WGS = 'gs://cpg-tob-wgs-temporary/joint_vcf/v1/work/combiner/genomes.mt'
+TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
 
 GNOMAD_LIFTOVER_LOADINGS = 'gs://cpg-reference/gnomad/gnomad_loadings_90k_liftover.ht'
 

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
@@ -1,0 +1,98 @@
+"""Generates loadings, scores, and eigenvalues for the HGDP,1KG, and tob-wgs dataset"""
+
+import click
+import pandas as pd
+import hail as hl
+from hail.experimental import lgt_to_gt
+
+GNOMAD_HGDP_1KG_MT = (
+    'gs://gcp-public-data--gnomad/release/3.1/mt/genomes/'
+    'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
+)
+
+TOB_WGS = 'gs://cpg-tob-wgs-temporary/joint_vcf/v1/work/combiner/genomes.mt'
+
+GNOMAD_V2_LOADINGS = (
+    'gs://gcp-public-data--gnomad/release/2.1/pca/gnomad.r2.1.pca_loadings.ht'
+)
+
+
+@click.command()
+@click.option('--output', help='GCS output path', required=True)
+def query(output):  # pylint: disable=too-many-locals
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    # Filter the matrix tables to rows whose keys appear in both datasets
+    mt_hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
+    mt_tob_wgs = hl.read_matrix_table(TOB_WGS)
+    # Remove 'allele' row key so that rows are the same (necessary step to join)
+    mt_hgdp_1kg = mt_hgdp_1kg.key_rows_by('locus')
+    mt_hgdp_1kg = mt_hgdp_1kg.drop('alleles')
+    join_rows_hgdp1kg_tobwgs = mt_hgdp_1kg.semi_join_rows(mt_tob_wgs.rows())
+    join_rows_tobwgs_hgdp1kg = mt_tob_wgs.semi_join_rows(mt_hgdp_1kg.rows())
+
+    # Join dataset by merging columns
+    # Entries and columns must be identical
+    change_lgt_to_gt = join_rows_tobwgs_hgdp1kg.annotate_entries(
+        GT=lgt_to_gt(join_rows_tobwgs_hgdp1kg.LGT, join_rows_tobwgs_hgdp1kg.LA)
+    )
+    select_entries_hgdp1kg = join_rows_hgdp1kg_tobwgs.select_entries(
+        join_rows_hgdp1kg_tobwgs.GT
+    )
+    select_entries_tobwgs = change_lgt_to_gt.select_entries(change_lgt_to_gt.GT)
+    # Only keep columns we need
+    select_columns_hgdp1kg = select_entries_hgdp1kg.select_cols(
+        select_entries_hgdp1kg.sample_qc
+    )
+    hgdp1kg_filtered = select_columns_hgdp1kg.drop('sample_qc')
+    tobwgs_filtered = select_entries_tobwgs
+    # Join datasets
+    hgdp1kg_tobwgs_joined = hgdp1kg_filtered.union_cols(tobwgs_filtered)
+
+    # liftover and get variants
+    ht_gnomad_loadings = hl.read_table(GNOMAD_V2_LOADINGS)
+    ht_gnomad_loadings.count()
+    # 94176
+    rg37 = hl.get_reference('GRCh37')
+    rg38 = hl.get_reference('GRCh38')
+    rg37.add_liftover(
+        'gs://hail-common/references/grch37_to_grch38.over.chain.gz', rg38
+    )
+    ht_gnomad_loadings_liftover = ht_gnomad_loadings.annotate(
+        liftover=hl.liftover(ht_gnomad_loadings.locus, 'GRCh38', include_strand=False),
+        old_locus=ht_gnomad_loadings.locus,
+    )
+    ht_gnomad_loadings_liftover = ht_gnomad_loadings_liftover.key_by(
+        locus=ht_gnomad_loadings_liftover.liftover
+    )
+
+    # add liftover into the filtered, combined matrix table
+    hgdp1kg_tobwgs_liftover = hgdp1kg_tobwgs_joined.annotate_rows(
+        rows_to_keep=ht_gnomad_loadings_liftover[hgdp1kg_tobwgs_joined.locus]
+    )
+    hgdp1kg_tobwgs_filt = hgdp1kg_tobwgs_liftover.filter_rows(
+        hgdp1kg_tobwgs_liftover.locus == hgdp1kg_tobwgs_liftover.rows_to_keep.liftover
+    )
+
+    # Perform PCA
+    eigenvalues_path = f'{output}/eigenvalues.csv'
+    scores_path = f'{output}/scores.ht'
+    loadings_path = f'{output}/loadings.ht'
+
+    # test on 100 samples
+    mt_head = hgdp1kg_tobwgs_filt.head(n=hgdp1kg_tobwgs_filt.count_rows(), n_cols=100)
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(
+        mt_head.GT, compute_loadings=True, k=20
+    )
+    # save the list of eigenvalues
+    eigenvalues_df = pd.DataFrame(eigenvalues)
+    eigenvalues_df.to_csv(eigenvalues_path, index=False)
+    # save the scores and loadings as a hail table
+    scores.write(scores_path, overwrite=True)
+    loadings.write(loadings_path, overwrite=True)
+
+
+if __name__ == '__main__':
+    query()  # pylint: disable=no-value-for-parameter

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
@@ -22,11 +22,11 @@ def query(output):  # pylint: disable=too-many-locals
 
     hl.init(default_reference='GRCh38')
 
-    # Filter the matrix tables to rows whose keys appear in both datasets
     mt_hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
     mt_tob_wgs = hl.read_matrix_table(TOB_WGS)
     # make keys the same between datasets
     mt_tob_wgs = mt_tob_wgs.key_rows_by('locus', 'alleles')
+    # Filter the matrix tables to rows whose keys appear in both datasets
     join_rows_hgdp1kg_tobwgs = mt_hgdp_1kg.semi_join_rows(mt_tob_wgs.rows())
     join_rows_tobwgs_hgdp1kg = mt_tob_wgs.semi_join_rows(mt_hgdp_1kg.rows())
 

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
@@ -35,13 +35,8 @@ def query(output):  # pylint: disable=too-many-locals
 
     # Join datasets by merging columns
     # Entries and columns must be identical
-    change_lgt_to_gt = join_rows_tobwgs_liftover.annotate_entries(
-        GT=lgt_to_gt(join_rows_tobwgs_liftover.LGT, join_rows_tobwgs_liftover.LA)
-    )
-    select_entries_hgdp1kg = join_rows_hgdp1kg_liftover.select_entries(
-        join_rows_hgdp1kg_liftover.GT
-    )
-    select_entries_tobwgs = change_lgt_to_gt.select_entries(change_lgt_to_gt.GT)
+    tob_wgs = tob_wgs.select_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))
+    hgdp_1kg = hgdp_1kg.select_entries(hgdp_1kg.GT)
 
     # Only keep columns we need
     select_columns_hgdp1kg = select_entries_hgdp1kg.select_cols(

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
@@ -12,9 +12,7 @@ GNOMAD_HGDP_1KG_MT = (
 
 TOB_WGS = 'gs://cpg-tob-wgs-temporary/joint_vcf/v1/work/combiner/genomes.mt'
 
-GNOMAD_V2_LOADINGS = (
-    'gs://gcp-public-data--gnomad/release/2.1/pca/gnomad.r2.1.pca_loadings.ht'
-)
+GNOMAD_LIFTOVER_LOADINGS = 'gs://cpg-reference/gnomad/gnomad_loadings_90k_liftover.ht'
 
 
 @click.command()
@@ -27,20 +25,32 @@ def query(output):  # pylint: disable=too-many-locals
     # Filter the matrix tables to rows whose keys appear in both datasets
     mt_hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
     mt_tob_wgs = hl.read_matrix_table(TOB_WGS)
-    # Remove 'allele' row key so that rows are the same (necessary step to join)
-    mt_hgdp_1kg = mt_hgdp_1kg.key_rows_by('locus')
-    mt_hgdp_1kg = mt_hgdp_1kg.drop('alleles')
+    # make keys the same between datasets
+    mt_tob_wgs = mt_tob_wgs.key_rows_by('locus', 'alleles')
     join_rows_hgdp1kg_tobwgs = mt_hgdp_1kg.semi_join_rows(mt_tob_wgs.rows())
     join_rows_tobwgs_hgdp1kg = mt_tob_wgs.semi_join_rows(mt_hgdp_1kg.rows())
 
-    # Join dataset by merging columns
+    # add gnomad liftover loading data to both matrices
+    ht_gnomad_loadings_liftover = hl.read_table(GNOMAD_LIFTOVER_LOADINGS)
+    hgdp1kg_select_variants = join_rows_hgdp1kg_tobwgs.annotate_rows(
+        rows_to_keep=ht_gnomad_loadings_liftover[join_rows_hgdp1kg_tobwgs.locus]
+    )
+    hgdp1kg_filt = hgdp1kg_select_variants.filter_rows(
+        hgdp1kg_select_variants.locus == hgdp1kg_select_variants.rows_to_keep.liftover
+    )
+    tobwgs_select_variants = join_rows_tobwgs_hgdp1kg.annotate_rows(
+        rows_to_keep=ht_gnomad_loadings_liftover[join_rows_tobwgs_hgdp1kg.locus]
+    )
+    tobwgs_filt = tobwgs_select_variants.filter_rows(
+        tobwgs_select_variants.locus == tobwgs_select_variants.rows_to_keep.liftover
+    )
+
+    # Join datasets by merging columns
     # Entries and columns must be identical
-    change_lgt_to_gt = join_rows_tobwgs_hgdp1kg.annotate_entries(
-        GT=lgt_to_gt(join_rows_tobwgs_hgdp1kg.LGT, join_rows_tobwgs_hgdp1kg.LA)
+    change_lgt_to_gt = tobwgs_filt.annotate_entries(
+        GT=lgt_to_gt(tobwgs_filt.LGT, tobwgs_filt.LA)
     )
-    select_entries_hgdp1kg = join_rows_hgdp1kg_tobwgs.select_entries(
-        join_rows_hgdp1kg_tobwgs.GT
-    )
+    select_entries_hgdp1kg = hgdp1kg_filt.select_entries(hgdp1kg_filt.GT)
     select_entries_tobwgs = change_lgt_to_gt.select_entries(change_lgt_to_gt.GT)
     # Only keep columns we need
     select_columns_hgdp1kg = select_entries_hgdp1kg.select_cols(
@@ -51,38 +61,15 @@ def query(output):  # pylint: disable=too-many-locals
     # Join datasets
     hgdp1kg_tobwgs_joined = hgdp1kg_filtered.union_cols(tobwgs_filtered)
 
-    # liftover and get variants
-    ht_gnomad_loadings = hl.read_table(GNOMAD_V2_LOADINGS)
-    ht_gnomad_loadings.count()
-    # 94176
-    rg37 = hl.get_reference('GRCh37')
-    rg38 = hl.get_reference('GRCh38')
-    rg37.add_liftover(
-        'gs://hail-common/references/grch37_to_grch38.over.chain.gz', rg38
-    )
-    ht_gnomad_loadings_liftover = ht_gnomad_loadings.annotate(
-        liftover=hl.liftover(ht_gnomad_loadings.locus, 'GRCh38', include_strand=False),
-        old_locus=ht_gnomad_loadings.locus,
-    )
-    ht_gnomad_loadings_liftover = ht_gnomad_loadings_liftover.key_by(
-        locus=ht_gnomad_loadings_liftover.liftover
-    )
-
-    # add liftover into the filtered, combined matrix table
-    hgdp1kg_tobwgs_liftover = hgdp1kg_tobwgs_joined.annotate_rows(
-        rows_to_keep=ht_gnomad_loadings_liftover[hgdp1kg_tobwgs_joined.locus]
-    )
-    hgdp1kg_tobwgs_filt = hgdp1kg_tobwgs_liftover.filter_rows(
-        hgdp1kg_tobwgs_liftover.locus == hgdp1kg_tobwgs_liftover.rows_to_keep.liftover
-    )
-
     # Perform PCA
     eigenvalues_path = f'{output}/eigenvalues.csv'
     scores_path = f'{output}/scores.ht'
     loadings_path = f'{output}/loadings.ht'
 
     # test on 100 samples
-    mt_head = hgdp1kg_tobwgs_filt.head(n=hgdp1kg_tobwgs_filt.count_rows(), n_cols=100)
+    mt_head = hgdp1kg_tobwgs_joined.head(
+        n=hgdp1kg_tobwgs_joined.count_rows(), n_cols=100
+    )
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(
         mt_head.GT, compute_loadings=True, k=20
     )

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/main.py
@@ -1,0 +1,28 @@
+"""Run hgdp_1kg_tob_wgs_pca.py using the analysis runner."""
+
+import os
+import hail as hl
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+OUTPUT = os.getenv('OUTPUT')
+assert OUTPUT
+
+hl.init(default_reference='GRCh38')
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name='hgdp1kg tobwgs pca', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'hgdp_1kg_tob_wgs_pca.py --output={OUTPUT}',
+    max_age='10h',
+    num_secondary_workers=100,
+    packages=['click'],
+    job_name='hgdp1kg-tobwgs-pca',
+)
+
+batch.run()


### PR DESCRIPTION
This script combines the HGDP + 1KG dataset with the TOB-WGS dataset, then filters rows to the 90K variants from gnomAD. Once filtered, a PCA is performed.