### PR TITLE
Increase worker boot disk size

### DIFF
--- a/scripts/hail_batch/ld_prune/main.py
+++ b/scripts/hail_batch/ld_prune/main.py
@@ -20,9 +20,10 @@ dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_ld_prune.py --output={OUTPUT}',
     max_age='5h',
-    num_secondary_workers=300,
+    num_secondary_workers=100,
     packages=['click', 'gnomad'],
     job_name='ld-prune',
+    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
After updating the analysis runner to v1.7.0, I added in the option worker_boot_disk_size and set this to 200. I also reduced the number of secondary workers back down to 100, since increasing to 300 doesn't really change things (what matters more is the number of non-preemptible workers).