### PR TITLE
Increase the number of non_preemptible workers

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/README.md
@@ -3,7 +3,7 @@
 This runs a Hail query script in Dataproc using Hail Batch in order to perform a pca on the 1KG + HGDP + TOB-WGS dataset. To run, use conda to install the analysis-runner, then execute the following command:
 
 ```sh
-analysis-runner --dataset ancestry \
---access-level test --output-dir "gs://cpg-ancestry-analysis/1kg_hgdp_tobwgs_pca/v0" \
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "gs://cpg-tob-wgs-analysis/1kg_hgdp_tobwgs_pca/v0" \
 --description "hgdp1kg tobwgs pca" python3 main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
@@ -25,7 +25,6 @@ def query(output):  # pylint: disable=too-many-locals
     hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
     tob_wgs = hl.read_matrix_table(TOB_WGS).key_rows_by('locus', 'alleles')
     loadings = hl.read_table(GNOMAD_LIFTOVER_LOADINGS).key_by('locus', 'alleles')
-    mt_path = f'{output}/hgdp1kg_tobwgs_joined.mt'
 
     # filter to loci that are contained in both tables and the loadings
     hgdp_1kg = hgdp_1kg.filter_rows(
@@ -43,6 +42,7 @@ def query(output):  # pylint: disable=too-many-locals
     hgdp_1kg = hgdp_1kg.head(None, n_cols=50)
     # Join datasets
     hgdp1kg_tobwgs_joined = hgdp_1kg.union_cols(tob_wgs)
+    mt_path = f'{output}/hgdp1kg_tobwgs_joined.mt'
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.checkpoint(mt_path)
 
     # Perform PCA

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/main.py
@@ -19,8 +19,8 @@ batch = hb.Batch(name='hgdp1kg tobwgs pca', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_tob_wgs_pca.py --output={OUTPUT}',
-    max_age='10h',
-    num_secondary_workers=100,
+    max_age='24h',
+    num_workers=50,
     packages=['click'],
     job_name='hgdp1kg-tobwgs-pca',
 )


### PR DESCRIPTION
I increased the number of non_preemptible workers to 50 (under the named argumernt 'num_workers', within the hail_dataproc_job function) and removed all preemptible (secondary) workers. I also increased the max age from 10 hours to 24 hours. To ensure the joined TOB-WGS + HGDP/1kG dataset is saved before running the PCA function, I used the `checkpoint` function from hail, and moved this up before the PCA function is called. I also changed the dataset to tob-wgs and the access level to standard (the same command which was run earlier today, but just wasn't updated).