### PR TITLE
PCA and variant frequency analsis for NFE samples

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/README.md
@@ -1,0 +1,9 @@
+# Perform pca and variant analysis on NFE samples
+
+This runs a Hail query script in Dataproc using Hail Batch in order to perform pca and variant frequency analysis on non-Finnish European (nfe) samples from the 1KG + HGDP dataset. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset ancestry \
+--access-level test --output-dir "gs://cpg-ancestry-test/1kg_hgdp_nfe/v0" \
+--description "pca nfe" python3 main.py
+```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to perform p
 
 ```sh
 analysis-runner --dataset ancestry \
---access-level test --output-dir "gs://cpg-ancestry-test/1kg_hgdp_nfe/v0" \
+--access-level test --output-dir "gs://cpg-ancestry-temporary/1kg_hgdp_nfe/v0" \
 --description "pca nfe" python3 main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to perform p
 
 ```sh
 analysis-runner --dataset ancestry \
---access-level test --output-dir "gs://cpg-ancestry-temporary/1kg_hgdp_nfe/v0" \
+--access-level standard --output-dir "gs://cpg-ancestry-analysis/1kg_hgdp_nfe/v0" \
 --description "pca nfe" python3 main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
@@ -53,3 +53,7 @@ def query(output):  # pylint: disable=too-many-locals
     hgdp_1kg = hgdp_1kg.semi_join_rows(gnomad_only_variants)
     hgdp_1kg_path = f'{output}/hgdp_1kg_nfe_variants.mt'
     mt.write(hgdp_1kg_path)
+
+
+if __name__ == '__main__':
+    query()  # pylint: disable=no-value-for-parameter

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
@@ -63,8 +63,13 @@ def query(output):  # pylint: disable=too-many-locals
         gnomad_popmax_AF=hgdp_1kg_row.gnomad_popmax.AF,
         TOB_WGS_AF=tob_wgs_row.gt_stats.AF,
     )
-    loadings_gnomad_path = f'{output}/gnomad_loadings_annotated_variants.mt'
-    mt.write(loadings_gnomad_path)
+    population_af_metadata = hgdp_1kg.gnomad_freq_meta.collect()
+    loadings_gnomad = loadings_gnomad.annotate_globals(
+        gnomad_freq_meta=population_af_metadata
+    )
+    gnomad_variants = loadings_gnomad.drop('loadings')
+    gnomad_variant_path = f'{output}/gnomad_annotated_variants.mt'
+    gnomad_variants.write(gnomad_variant_path)
 
 
 if __name__ == '__main__':

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
@@ -56,19 +56,12 @@ def query(output):  # pylint: disable=too-many-locals
     # Get gnomAD allele frequency of variants that aren't in TOB-WGS
     loadings_gnomad = hl.read_table(GNOMAD_LIFTOVER_LOADINGS).key_by('locus', 'alleles')
     hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
+    hgdp_1kg_row = hgdp_1kg.rows()[loadings_gnomad.locus, loadings_gnomad.alleles]
+    tob_wgs_row = tob_wgs.rows()[loadings_gnomad.locus, loadings_gnomad.alleles]
     loadings_gnomad = loadings_gnomad.annotate(
-        gnomad_AF=hgdp_1kg.rows()[
-            loadings_gnomad.locus, loadings_gnomad.alleles
-        ].gnomad_freq.AF,
-        gnomad_popmax_AF=hgdp_1kg.rows()[
-            loadings_gnomad.locus, loadings_gnomad.alleles
-        ].gnomad_popmax.AF,
-        TOB_variant=hl.is_defined(
-            mt.rows()[loadings_gnomad.locus, loadings_gnomad.alleles].gnomad_popmax.AF
-        ),
-        TOB_WGS_AF=tob_wgs.rows()[
-            loadings_gnomad.locus, loadings_gnomad.alleles
-        ].gt_stats.AF,
+        gnomad_AF=hgdp_1kg_row.gnomad_freq.AF,
+        gnomad_popmax_AF=hgdp_1kg_row.gnomad_popmax.AF,
+        TOB_WGS_AF=tob_wgs_row.gt_stats.AF,
     )
     loadings_gnomad_path = f'{output}/gnomad_loadings_annotated_variants.mt'
     mt.write(loadings_gnomad_path)

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
@@ -51,5 +51,5 @@ def query(output):  # pylint: disable=too-many-locals
     gnomad_only_variants = loadings_gnomad.anti_join(mt.rows())
     hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
     hgdp_1kg = hgdp_1kg.semi_join_rows(gnomad_only_variants)
-    hgdp_1kg_path = f'{output}/hgdp_1kg_nfe_variants.csv'
+    hgdp_1kg_path = f'{output}/hgdp_1kg_nfe_variants.mt'
     mt.write(hgdp_1kg_path)

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
@@ -47,9 +47,7 @@ def query(output):  # pylint: disable=too-many-locals
     loadings.write(loadings_path, overwrite=True)
 
     # get TOB-WGS allele frequencies
-    tob_wgs = hl.read_matrix_table(
-        'gs://cpg-tob-wgs-temporary/joint_vcf/v1/raw/genomes.mt'
-    ).key_rows_by('locus', 'alleles')
+    tob_wgs = hl.read_matrix_table(TOB_WGS).key_rows_by('locus', 'alleles')
     tob_wgs = tob_wgs.annotate_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))
     tob_wgs = tob_wgs.annotate_rows(
         gt_stats=hl.agg.call_stats(tob_wgs.GT, tob_wgs.alleles)

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
@@ -68,8 +68,8 @@ def query(output):  # pylint: disable=too-many-locals
         gnomad_freq_meta=population_af_metadata
     )
     gnomad_variants = loadings_gnomad.drop('loadings')
-    gnomad_variant_path = f'{output}/gnomad_annotated_variants.mt'
-    gnomad_variants.write(gnomad_variant_path)
+    gnomad_variants_path = f'{output}/gnomad_annotated_variants.mt'
+    gnomad_variants.write(gnomad_variants_path)
 
 
 if __name__ == '__main__':

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/hgdp_1kg_tob_wgs_nfe.py
@@ -1,0 +1,55 @@
+"""Perform pca on nfe samples from the HGDP,1KG, and tob-wgs dataset"""
+
+import click
+import pandas as pd
+import hail as hl
+
+HGDP1KG_TOBWGS = (
+    'gs://cpg-tob-wgs-analysis/1kg_hgdp_tobwgs_pca/'
+    'v1/hgdp1kg_tobwgs_joined_all_samples.mt'
+)
+
+GNOMAD_LIFTOVER_LOADINGS = 'gs://cpg-reference/gnomad/gnomad_loadings_90k_liftover.ht'
+
+GNOMAD_HGDP_1KG_MT = (
+    'gs://gcp-public-data--gnomad/release/3.1/mt/genomes/'
+    'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
+)
+
+
+@click.command()
+@click.option('--output', help='GCS output path', required=True)
+def query(output):  # pylint: disable=too-many-locals
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    mt = hl.read_matrix_table(HGDP1KG_TOBWGS)
+    mt = mt.annotate_cols(TOB_WGS=mt.s.contains('TOB'))
+    # Get NFE samples only
+    mt = mt.filter_cols(
+        (mt.hgdp_1kg_metadata.population_inference.pop == 'nfe') | (mt.TOB_WGS)
+    )
+    mt_path = f'{output}/hgdp1kg_nfe_samples.mt'
+    if not hl.hadoop_exists(mt_path):
+        mt.write(mt_path)
+
+    # Perform PCA
+    eigenvalues_path = f'{output}/eigenvalues.csv'
+    scores_path = f'{output}/scores.ht'
+    loadings_path = f'{output}/loadings.ht'
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(
+        mt.GT, compute_loadings=True, k=20
+    )
+    eigenvalues_df = pd.DataFrame(eigenvalues)
+    eigenvalues_df.to_csv(eigenvalues_path, index=False)
+    scores.write(scores_path, overwrite=True)
+    loadings.write(loadings_path, overwrite=True)
+
+    # Get gnomAD allele frequency of variants that aren't in TOB-WGS
+    loadings_gnomad = hl.read_table(GNOMAD_LIFTOVER_LOADINGS).key_by('locus', 'alleles')
+    gnomad_only_variants = loadings_gnomad.anti_join(mt.rows())
+    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
+    hgdp_1kg = hgdp_1kg.semi_join_rows(gnomad_only_variants)
+    hgdp_1kg_path = f'{output}/hgdp_1kg_nfe_variants.csv'
+    mt.write(hgdp_1kg_path)

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/main.py
@@ -1,0 +1,28 @@
+"""Run hgdp_1kg_ld_prune.py using the analysis runner."""
+
+import os
+import hail as hl
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+OUTPUT = os.getenv('OUTPUT')
+assert OUTPUT
+
+hl.init(default_reference='GRCh38')
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name='nfe pca', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'hgdp_1kg_tob_wgs_nfe.py --output={OUTPUT}',
+    max_age='24h',
+    num_workers=50,
+    packages=['click'],
+    job_name='nfe-pca',
+)
+
+batch.run()

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe/main.py
@@ -1,4 +1,4 @@
-"""Run hgdp_1kg_ld_prune.py using the analysis runner."""
+"""Entry point for the analysis runner."""
 
 import os
 import hail as hl


### PR DESCRIPTION
This script performs a PCA on NFE samples only from the combined HGDP/1kG + TOB-WGS dataset. It also filters for variants which are in the gnomad loadings, but not in the TOB-WGS data.