### PR TITLE
Change filename in dataproc.hail_dataproc_job function

### DIFF
--- a/scripts/hail_batch/check_sample_genotype/main.py
+++ b/scripts/hail_batch/check_sample_genotype/main.py
@@ -18,7 +18,7 @@ batch = hb.Batch(name='check sample genotype', backend=service_backend)
 
 dataproc.hail_dataproc_job(
     batch,
-    f'plot_loadings_nfe.py --output={OUTPUT}',
+    f'check_genotype.py --output={OUTPUT}',
     max_age='5h',
     num_secondary_workers=100,
     packages=['click', 'pyarrow'],


### PR DESCRIPTION
I changed the filename in the dataproc.hail_dataproc_job function to `check_genotype.py`, rather than `plot_loadings_nfe.py` (the old filename), which should fix the problem of the analysis runner failing.