### PR TITLE
Increase number of non_preemptible workers

### DIFF
--- a/scripts/hail_batch/check_sample_genotype/main.py
+++ b/scripts/hail_batch/check_sample_genotype/main.py
@@ -20,7 +20,7 @@ dataproc.hail_dataproc_job(
     batch,
     f'check_genotype.py --output={OUTPUT}',
     max_age='5h',
-    num_secondary_workers=100,
+    num_workers=50,
     packages=['click', 'pyarrow'],
     job_name='check sample genotype',
 )


### PR DESCRIPTION
I increased the number of non_preemptible workers to 50 (under the named argumernt 'num_workers', within the hail_dataproc_job function) and removed all preemptible (secondary) workers. This has helped previously due to shuffles causing repetitive failures.