### PR TITLE
Add flags to copy

### DIFF
--- a/scripts/copy_1kg_hgdp_tob_wgs_pca.sh
+++ b/scripts/copy_1kg_hgdp_tob_wgs_pca.sh
@@ -3,5 +3,5 @@
 set -ex
 
 # Copy a subset of the data to the `test` bucket.
-gsutil cp gs://cpg-tob-wgs-analysis/1kg_hgdp_tobwgs_pca/v1/hgdp1kg_tobwgs_joined_all_samples.mt gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/
-gsutil cp gs://cpg-tob-wgs-analysis/1kg_hgdp_nfe/v0/loadings.ht gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/
+gsutil -m cp -r gs://cpg-tob-wgs-analysis/1kg_hgdp_tobwgs_pca/v1/hgdp1kg_tobwgs_joined_all_samples.mt gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/
+gsutil -m cp -r gs://cpg-tob-wgs-analysis/1kg_hgdp_nfe/v0/loadings.ht gs://cpg-tob-wgs-analysis/1kg_hgdp_nfe/v0/


### PR DESCRIPTION
I added in a `-r` flag to copy both files, as they have a folder structure. I also added in the `-m` flag, which performs multi-threading. Finally, I changed th e output directorties to mirror the original directories (as suggested by Leo), since this will add in versioning in case I have multiple iterations of these files.