### PR TITLE
Add densify function before calculating AF for TOB-WGS data

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/README.md
@@ -1,0 +1,9 @@
+# Densify TOB-WGS data
+
+This runs a Hail query script in Dataproc using Hail Batch in order to densify the TOB-WGS matrix. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "gs://cpg-tob-wgs-analysis/1kg_hgdp_densify/v0" \
+--description "densify tob-wgs" python3 main.py
+```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
@@ -1,6 +1,5 @@
 """
 Test densify function on TOB-WGS data.
-
 """
 
 import click

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
@@ -1,0 +1,56 @@
+"""
+Test densify function on TOB-WGS data.
+
+"""
+
+import click
+import hail as hl
+from hail.experimental import lgt_to_gt
+
+
+GNOMAD_LIFTOVER_LOADINGS = 'gs://cpg-reference/gnomad/gnomad_loadings_90k_liftover.ht'
+
+GNOMAD_HGDP_1KG_MT = (
+    'gs://gcp-public-data--gnomad/release/3.1/mt/genomes/'
+    'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
+)
+
+TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
+
+
+@click.command()
+@click.option('--output', help='GCS output path', required=True)
+def query(output):  # pylint: disable=too-many-locals
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    # get TOB-WGS allele frequencies
+    tob_wgs = hl.read_matrix_table(TOB_WGS).key_rows_by('locus', 'alleles')
+    tob_wgs = hl.experimental.densify(tob_wgs)
+    tob_wgs = tob_wgs.annotate_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))
+    tob_wgs = tob_wgs.annotate_rows(
+        gt_stats=hl.agg.call_stats(tob_wgs.GT, tob_wgs.alleles)
+    )
+
+    # Get gnomAD allele frequency of variants that aren't in TOB-WGS
+    loadings_gnomad = hl.read_table(GNOMAD_LIFTOVER_LOADINGS).key_by('locus', 'alleles')
+    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
+    hgdp_1kg_row = hgdp_1kg.rows()[loadings_gnomad.locus, loadings_gnomad.alleles]
+    tob_wgs_row = tob_wgs.rows()[loadings_gnomad.locus, loadings_gnomad.alleles]
+    loadings_gnomad = loadings_gnomad.annotate(
+        gnomad_AF=hgdp_1kg_row.gnomad_freq.AF,
+        gnomad_popmax_AF=hgdp_1kg_row.gnomad_popmax.AF,
+        TOB_WGS_AF=tob_wgs_row.gt_stats.AF,
+    )
+    population_af_metadata = hgdp_1kg.gnomad_freq_meta.collect()
+    loadings_gnomad = loadings_gnomad.annotate_globals(
+        gnomad_freq_meta=population_af_metadata
+    )
+    gnomad_variants = loadings_gnomad.drop('loadings')
+    gnomad_variants_path = f'{output}/gnomad_annotated_variants_densified.ht'
+    gnomad_variants.write(gnomad_variants_path)
+
+
+if __name__ == '__main__':
+    query()  # pylint: disable=no-value-for-parameter

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/main.py
@@ -1,0 +1,28 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hail as hl
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+OUTPUT = os.getenv('OUTPUT')
+assert OUTPUT
+
+hl.init(default_reference='GRCh38')
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name=f'densify_tobwgs', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'hgdp_1kg_tob_wgs_densify.py --output={OUTPUT}',
+    max_age='24h',
+    num_workers=50,
+    packages=['click'],
+    job_name=f'densify_tobwgs',
+)
+
+batch.run()


### PR DESCRIPTION
I tested the densify function on a small subset of the TOB-WGS data, prior to calling the `lgt_to_gt` function. The AF changes after calling this function, and therefore I'm curious to see whether this has anything to do with the strange AF distribution we were seeing for the TOB-WGS data. This script is intended to get the AF after densifying the data, so that I can see how it affects the AF for the entire dataset.