### PR TITLE
Choose new variants for TOB-WGS + HGDP/1KG dataset

### DIFF
--- a/scripts/hail_batch/variant_selection/README.md
+++ b/scripts/hail_batch/variant_selection/README.md
@@ -1,0 +1,9 @@
+# Variant selection for HGDP/1kG + TOB-WGS data
+
+This runs a Hail query script in Dataproc using Hail Batch in order to select a set o f variants from the HGDP/1kG + TOB-WGS data, based off of gnomAD v3 parameters. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level test --output-dir "gs://cpg-ancestry-temporary/1kg_hgdp_ld_pruning/v0" \
+--description "ld pruning" python3 main.py
+```

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -1,0 +1,70 @@
+"""Pipeline for choosing new variants for HGDP/1kG + TOB-WGS data"""
+
+import click
+import hail as hl
+from hail.experimental import lgt_to_gt
+
+GNOMAD_HGDP_1KG_MT = (
+    'gs://gcp-public-data--gnomad/release/3.1/mt/genomes/'
+    'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
+)
+
+TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
+
+
+@click.command()
+@click.option('--output', help='GCS output path', required=True)
+def query(output):  # pylint: disable=too-many-locals
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
+    tob_wgs = hl.read_matrix_table(TOB_WGS).key_rows_by('locus', 'alleles')
+
+    # filter to loci that are contained in both matrix tables
+    hgdp_1kg = hgdp_1kg.filter_rows(
+        hl.is_defined(tob_wgs.index_rows(hgdp_1kg['locus'], hgdp_1kg['alleles']))
+    )
+    tob_wgs = tob_wgs.semi_join_rows(hgdp_1kg.rows())
+
+    # Entries and columns must be identical
+    tob_wgs_select = tob_wgs.select_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))
+    hgdp_1kg_select = hgdp_1kg.select_entries(hgdp_1kg.GT)
+    hgdp_1kg_select = hgdp_1kg_select.select_cols()
+    # Join datasets
+    hgdp1kg_tobwgs_joined = hgdp_1kg_select.union_cols(tob_wgs_select)
+    # Add in metadata information
+    hgdp_1kg_metadata = hgdp_1kg.cols()
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.annotate_cols(
+        hgdp_1kg_metadata=hgdp_1kg_metadata[hgdp1kg_tobwgs_joined.s]
+    )
+    mt_path = f'{output}/hgdp1kg_tobwgs_joined_all_samples.mt'
+    if not hl.hadoop_exists(mt_path):
+        hgdp1kg_tobwgs_joined.write(mt_path)
+    hgdp1kg_tobwgs_joined = hl.read_matrix_table(mt_path)
+
+    # choose variants based off of gnomAD v3 parameters
+    hgdp1kg_tobwgs_joined = hl.variant_qc(hgdp1kg_tobwgs_joined)
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.annotate_rows(
+        IB=hl.agg.inbreeding(
+            hgdp1kg_tobwgs_joined.GT, hgdp1kg_tobwgs_joined.variant_qc.AF[1]
+        )
+    )
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.filter_rows(
+        (hl.len(hgdp1kg_tobwgs_joined.alleles) == 2)
+        & (hgdp1kg_tobwgs_joined.locus.in_autosome())
+        & (hgdp1kg_tobwgs_joined.variant_qc.AF[1] > 0.001)
+        & (hgdp1kg_tobwgs_joined.variant_qc.call_rate > 0.99)
+        & (hgdp1kg_tobwgs_joined.IB.f_stat > -0.25)
+    )
+    pruned_variant_table = hl.ld_prune(
+        hgdp1kg_tobwgs_joined.GT, r2=0.1, bp_window_size=500000
+    )
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.filter_rows(
+        hl.is_defined(pruned_variant_table[hgdp1kg_tobwgs_joined.row_key])
+    )
+
+
+if __name__ == '__main__':
+    query()  # pylint: disable=no-value-for-parameter

--- a/scripts/hail_batch/variant_selection/main.py
+++ b/scripts/hail_batch/variant_selection/main.py
@@ -1,0 +1,29 @@
+"""Run hgdp_1kg_tob_wgs_variant_selection.py using the analysis runner."""
+
+import os
+import hail as hl
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+OUTPUT = os.getenv('OUTPUT')
+assert OUTPUT
+
+hl.init(default_reference='GRCh38')
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name='variant selection', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'hgdp_1kg_tob_wgs_variant_selection.py --output={OUTPUT}',
+    max_age='5h',
+    num_secondary_workers=100,
+    packages=['click'],
+    job_name='variant-selection',
+    worker_boot_disk_size=200,
+)
+
+batch.run()


### PR DESCRIPTION
Since the ~90k variants that were previously chosen by gnomAD were not consistently capturing genotypes for the entire cohort, Loic and I went through the gnomAD v3 marker selection process, but applied to the combined TOB-WGS + HGDP/1kG data. By doing so, this should remove some of the batch effect we're seeing. The aim is to first filter out variants with an AF of 0.1%, but then see how the list changes as we increase this threshold.