### PR TITLE
Densify TOB-WGS data before joining HGDP/1kG and TOB-WGS datasets

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca/hgdp_1kg_tob_wgs_pca.py
@@ -45,15 +45,15 @@ def query(output):  # pylint: disable=too-many-locals
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.annotate_cols(
         hgdp_1kg_metadata=hgdp_1kg_metadata[hgdp1kg_tobwgs_joined.s]
     )
-    mt_path = f'{output}/hgdp1kg_tobwgs_joined_all_samples_densified.mt'
+    mt_path = f'{output}/hgdp1kg_tobwgs_joined_all_samples.mt'
     if not hl.hadoop_exists(mt_path):
         hgdp1kg_tobwgs_joined.write(mt_path)
     hgdp1kg_tobwgs_joined = hl.read_matrix_table(mt_path)
 
     # Perform PCA
-    eigenvalues_path = f'{output}/eigenvalues_densified.csv'
-    scores_path = f'{output}/scores_densified.ht'
-    loadings_path = f'{output}/loadings_densified.ht'
+    eigenvalues_path = f'{output}/eigenvalues.csv'
+    scores_path = f'{output}/scores.ht'
+    loadings_path = f'{output}/loadings.ht'
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(
         hgdp1kg_tobwgs_joined.GT, compute_loadings=True, k=20
     )


### PR DESCRIPTION
I densified the TOB-WGS dataset before filtering and converting LGT to GT entries. We've found that densifying the sparse TOB-WGS mt is essential, as it affects downstream results. Densifying is particularly important in this script, where the output is a joined HGDP/1kG + TOB-WGS mt which is used in many downstream analyses. In order to compare the densified and non-densified matrix tables, I renamed the output files in this script by appending `_densified` to the end.