### PR TITLE
Test `densify` function on the full TOB-WGS dataset

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to densify t
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "gs://cpg-tob-wgs-analysis/1kg_hgdp_densify/v0" \
+--access-level full --output-dir "gs://cpg-tob-wgs-main/1kg_hgdp_densify/v2" \
 --description "densify tob-wgs" python3 main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to densify t
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level full --output-dir "gs://cpg-tob-wgs-main/1kg_hgdp_densify/v2" \
+--access-level standard --output-dir "gs://cpg-tob-wgs-main/1kg_hgdp_densify/v2" \
 --description "densify tob-wgs" python3 main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
@@ -36,7 +36,7 @@ def query(output):  # pylint: disable=too-many-locals
     )
     tob_wgs = tob_wgs.semi_join_rows(hgdp_1kg.rows())
     tob_wgs_path = f'{output}/tob_wgs_filtered.mt'
-    tob_wgs = tob_wgs.checkpoint(tob_wgs_path)
+    tob_wgs.write(tob_wgs_path)
 
 
 if __name__ == '__main__':

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
@@ -35,7 +35,7 @@ def query(output):  # pylint: disable=too-many-locals
         & hl.is_defined(tob_wgs.index_rows(hgdp_1kg['locus'], hgdp_1kg['alleles']))
     )
     tob_wgs = tob_wgs.semi_join_rows(hgdp_1kg.rows())
-    tob_wgs_path = f'{output}/tob_wgs_filtered_densified.mt'
+    tob_wgs_path = f'{output}/tob_wgs_filtered.mt'
     tob_wgs = tob_wgs.checkpoint(tob_wgs_path)
 
 

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
@@ -4,7 +4,6 @@ Test densify function on TOB-WGS data.
 
 import click
 import hail as hl
-from hail.experimental import lgt_to_gt
 
 
 GNOMAD_LIFTOVER_LOADINGS = 'gs://cpg-reference/gnomad/gnomad_loadings_90k_liftover.ht'
@@ -14,7 +13,8 @@ GNOMAD_HGDP_1KG_MT = (
     'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
 )
 
-TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
+# contains batches 1-4
+TOB_WGS = 'gs://cpg-tob-wgs-main/mt/v2-raw.mt/'
 
 
 @click.command()
@@ -24,31 +24,19 @@ def query(output):  # pylint: disable=too-many-locals
 
     hl.init(default_reference='GRCh38')
 
-    # get TOB-WGS allele frequencies
-    tob_wgs = hl.read_matrix_table(TOB_WGS).key_rows_by('locus', 'alleles')
-    tob_wgs = hl.experimental.densify(tob_wgs)
-    tob_wgs = tob_wgs.annotate_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))
-    tob_wgs = tob_wgs.annotate_rows(
-        gt_stats=hl.agg.call_stats(tob_wgs.GT, tob_wgs.alleles)
-    )
-
-    # Get gnomAD allele frequency of variants that aren't in TOB-WGS
-    loadings_gnomad = hl.read_table(GNOMAD_LIFTOVER_LOADINGS).key_by('locus', 'alleles')
     hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
-    hgdp_1kg_row = hgdp_1kg.rows()[loadings_gnomad.locus, loadings_gnomad.alleles]
-    tob_wgs_row = tob_wgs.rows()[loadings_gnomad.locus, loadings_gnomad.alleles]
-    loadings_gnomad = loadings_gnomad.annotate(
-        gnomad_AF=hgdp_1kg_row.gnomad_freq.AF,
-        gnomad_popmax_AF=hgdp_1kg_row.gnomad_popmax.AF,
-        TOB_WGS_AF=tob_wgs_row.gt_stats.AF,
+    tob_wgs = hl.read_matrix_table(TOB_WGS).key_rows_by('locus', 'alleles')
+    loadings = hl.read_table(GNOMAD_LIFTOVER_LOADINGS).key_by('locus', 'alleles')
+
+    # filter to loci that are contained in both tables and the loadings after densifying
+    tob_wgs = hl.experimental.densify(tob_wgs)
+    hgdp_1kg = hgdp_1kg.filter_rows(
+        hl.is_defined(loadings.index(hgdp_1kg['locus'], hgdp_1kg['alleles']))
+        & hl.is_defined(tob_wgs.index_rows(hgdp_1kg['locus'], hgdp_1kg['alleles']))
     )
-    population_af_metadata = hgdp_1kg.gnomad_freq_meta.collect()
-    loadings_gnomad = loadings_gnomad.annotate_globals(
-        gnomad_freq_meta=population_af_metadata
-    )
-    gnomad_variants = loadings_gnomad.drop('loadings')
-    gnomad_variants_path = f'{output}/gnomad_annotated_variants_densified.ht'
-    gnomad_variants.write(gnomad_variants_path)
+    tob_wgs = tob_wgs.semi_join_rows(hgdp_1kg.rows())
+    tob_wgs_path = f'{output}/tob_wgs_filtered_densified.mt'
+    tob_wgs = tob_wgs.checkpoint(tob_wgs_path)
 
 
 if __name__ == '__main__':

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/main.py
@@ -19,8 +19,8 @@ batch = hb.Batch(name=f'densify_tobwgs', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_tob_wgs_densify.py --output={OUTPUT}',
-    max_age='24h',
-    num_workers=50,
+    max_age='12h',
+    num_secondary_workers=20,
     packages=['click'],
     job_name=f'densify_tobwgs',
 )


### PR DESCRIPTION
This script tests the `densify` function on the entire TOB-WGS data. First, the TOB-WGS dataset is densified, then variants are filtered to those within the HGDP/1kG and gnomAD 90k loadings mt. Additionally, I reduced the number of workers from 50 non-preemptible to 20 preemptible workers. The resulting matrix table is checkpointed for downstream use (should be less than 90k).