### PR TITLE
Remove print statements from variant selection exploration

### DIFF
--- a/scripts/hail_batch/variant_selection_exploration/hgdp_1kg_tob_wgs_variant_selection_exploration.py
+++ b/scripts/hail_batch/variant_selection_exploration/hgdp_1kg_tob_wgs_variant_selection_exploration.py
@@ -56,6 +56,9 @@ def query(output):  # pylint: disable=too-many-locals
         & (hgdp1kg_tobwgs_joined.variant_qc.call_rate > 0.99)
         & (hgdp1kg_tobwgs_joined.IB.f_stat > -0.25)
     )
+    mt_path = f'{output}/hgdp_1kg_tob_wgs_variant_selection.mt'
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.repartition(10, shuffle=False)
+    hgdp1kg_tobwgs_joined.write(mt_path, overwrite=True)
 
     histogram_plot = hl.plot.histogram(
         hgdp1kg_tobwgs_joined.variant_qc.AF[1],

--- a/scripts/hail_batch/variant_selection_exploration/hgdp_1kg_tob_wgs_variant_selection_exploration.py
+++ b/scripts/hail_batch/variant_selection_exploration/hgdp_1kg_tob_wgs_variant_selection_exploration.py
@@ -44,23 +44,19 @@ def query(output):  # pylint: disable=too-many-locals
 
     # choose variants based off of gnomAD v3 parameters
     hgdp1kg_tobwgs_joined = hl.variant_qc(hgdp1kg_tobwgs_joined)
-    print(hgdp1kg_tobwgs_joined.count_rows())
-    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.filter_rows(
-        (hl.len(hgdp1kg_tobwgs_joined.alleles) == 2)
-        & (hgdp1kg_tobwgs_joined.locus.in_autosome())
-        & (hgdp1kg_tobwgs_joined.variant_qc.AF[1] > 0.001)
-        & (hgdp1kg_tobwgs_joined.variant_qc.call_rate > 0.99)
-    )
-    print(hgdp1kg_tobwgs_joined.count_rows())
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.annotate_rows(
         IB=hl.agg.inbreeding(
             hgdp1kg_tobwgs_joined.GT, hgdp1kg_tobwgs_joined.variant_qc.AF[1]
         )
     )
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.filter_rows(
-        hgdp1kg_tobwgs_joined.IB.f_stat > -0.25
+        (hl.len(hgdp1kg_tobwgs_joined.alleles) == 2)
+        & (hgdp1kg_tobwgs_joined.locus.in_autosome())
+        & (hgdp1kg_tobwgs_joined.variant_qc.AF[1] > 0.001)
+        & (hgdp1kg_tobwgs_joined.variant_qc.call_rate > 0.99)
+        & (hgdp1kg_tobwgs_joined.IB.f_stat > -0.25)
     )
-    print(hgdp1kg_tobwgs_joined.count_rows())
+
     histogram_plot = hl.plot.histogram(
         hgdp1kg_tobwgs_joined.variant_qc.AF[1],
         legend='Allele Frequency',

--- a/scripts/hail_batch/variant_selection_exploration/main.py
+++ b/scripts/hail_batch/variant_selection_exploration/main.py
@@ -19,7 +19,8 @@ batch = hb.Batch(name='variant selection exploration', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_tob_wgs_variant_selection_exploration.py --output={OUTPUT}',
-    max_age='5h',
+    max_age='12h',
+    num_secondary_workers=20,
     packages=['click', 'selenium'],
     job_name='variant-selection-exploration',
 )


### PR DESCRIPTION
This script did not successfully finish running after being allocated 5 hours of run time. I checked which operations were taking the longest, and I can rule out `densify` and the `agg.inbreeding` functions. Rather, I think it's either in the row joins or some step within filtering, such as `index_rows`. Since the `print(count_rows())` statements were forcing evaluation after these steps, it was unnecessarily taking too long to complete.