### PR TITLE
Remove lines to write matrix table

### DIFF
--- a/scripts/hail_batch/variant_selection_exploration/hgdp_1kg_tob_wgs_variant_selection_exploration.py
+++ b/scripts/hail_batch/variant_selection_exploration/hgdp_1kg_tob_wgs_variant_selection_exploration.py
@@ -56,9 +56,6 @@ def query(output):  # pylint: disable=too-many-locals
         & (hgdp1kg_tobwgs_joined.variant_qc.call_rate > 0.99)
         & (hgdp1kg_tobwgs_joined.IB.f_stat > -0.25)
     )
-    mt_path = f'{output}/hgdp_1kg_tob_wgs_variant_selection.mt'
-    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.repartition(10, shuffle=False)
-    hgdp1kg_tobwgs_joined.write(mt_path, overwrite=True)
 
     histogram_plot = hl.plot.histogram(
         hgdp1kg_tobwgs_joined.variant_qc.AF[1],


### PR DESCRIPTION
Since the filtered matrix table is very large, we want to first explore how many variants we have at different allele frequencies before writing out the filtered variant mt.