### PR TITLE
Increase number of partitions and check number of rows from filtered mt

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densify/hgdp_1kg_tob_wgs_densify.py
@@ -35,8 +35,10 @@ def query(output):  # pylint: disable=too-many-locals
         & hl.is_defined(tob_wgs.index_rows(hgdp_1kg['locus'], hgdp_1kg['alleles']))
     )
     tob_wgs = tob_wgs.semi_join_rows(hgdp_1kg.rows())
+    tob_wgs = tob_wgs.cache()
+    print(tob_wgs.count_rows())
     tob_wgs_path = f'{output}/tob_wgs_filtered.mt'
-    tob_wgs = tob_wgs.repartition(100, shuffle=False)
+    tob_wgs = tob_wgs.repartition(1000, shuffle=False)
     tob_wgs.write(tob_wgs_path)
 
 


### PR DESCRIPTION
I increased the number of rows from 100 to 1000, since the previous script failed due to memory issues. Oddly, since the matrix table should be less than 90k rows, 100 partitions does seem sufficient, and therefore I added in a `count_rows()` statement to do a quick sanity check on how big the matrix table actually is. I also cached the tob_wgs data before printing the number of rows, so that I don't recompute the entire list of operations for printing and for saving the mt.