### PR TITLE
 Change AF to 1% and subsample to 1M variants before pruning

### DIFF
--- a/scripts/hail_batch/variant_selection/README.md
+++ b/scripts/hail_batch/variant_selection/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to select a 
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level test --output-dir "gs://cpg-ancestry-test/1kg_hgdp_ld_pruning/v0" \
+--access-level standard --output-dir "gs://cpg-tob-wgs-main/1kg_hgdp_ld_pruning/v0" \
 --description "ld pruning" python3 main.py
 ```

--- a/scripts/hail_batch/variant_selection/README.md
+++ b/scripts/hail_batch/variant_selection/README.md
@@ -1,9 +1,9 @@
 # Variant selection for HGDP/1kG + TOB-WGS data
 
-This runs a Hail query script in Dataproc using Hail Batch in order to select a set o f variants from the HGDP/1kG + TOB-WGS data, based off of gnomAD v3 parameters. To run, use conda to install the analysis-runner, then execute the following command:
+This runs a Hail query script in Dataproc using Hail Batch in order to select a set of variants from the HGDP/1kG + TOB-WGS data, based off of gnomAD v3 parameters. To run, use conda to install the analysis-runner, then execute the following command:
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level test --output-dir "gs://cpg-ancestry-temporary/1kg_hgdp_ld_pruning/v0" \
+--access-level test --output-dir "gs://cpg-ancestry-test/1kg_hgdp_ld_pruning/v0" \
 --description "ld pruning" python3 main.py
 ```

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -9,7 +9,8 @@ GNOMAD_HGDP_1KG_MT = (
     'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
 )
 
-TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
+# TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
+TOB_WGS = 'gs://cpg-tob-wgs-test/mt/test-v1-raw.mt'
 
 
 @click.command()

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -11,6 +11,8 @@ GNOMAD_HGDP_1KG_MT = (
 
 TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
 
+NUM_ROWS_BEFORE_LD_PRUNE = 1000000
+
 
 @click.command()
 @click.option('--output', help='GCS output path', required=True)
@@ -60,7 +62,7 @@ def query(output):  # pylint: disable=too-many-locals
     nrows = hgdp1kg_tobwgs_joined.count_rows()
     print(f'hgdp1kg_tobwgs_joined.count_rows() = {nrows}')
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.sample_rows(
-        1000000 / nrows, seed=12345
+        NUM_ROWS_BEFORE_LD_PRUNE / nrows, seed=12345
     )
 
     pruned_variant_table = hl.ld_prune(

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -9,8 +9,7 @@ GNOMAD_HGDP_1KG_MT = (
     'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
 )
 
-# TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
-TOB_WGS = 'gs://cpg-tob-wgs-test/mt/test-v1-raw.mt'
+TOB_WGS = 'gs://cpg-tob-wgs-main/joint_vcf/v1/raw/genomes.mt'
 
 
 @click.command()
@@ -22,9 +21,6 @@ def query(output):  # pylint: disable=too-many-locals
 
     hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
     tob_wgs = hl.read_matrix_table(TOB_WGS).key_rows_by('locus', 'alleles')
-
-    hgdp_1kg = hgdp_1kg.head(1000000)
-    tob_wgs = tob_wgs.head(1000000)
 
     # filter to loci that are contained in both matrix tables after densifying
     tob_wgs = hl.experimental.densify(tob_wgs)
@@ -61,9 +57,11 @@ def query(output):  # pylint: disable=too-many-locals
     )
 
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.cache()
-    # nrows = hgdp1kg_tobwgs_joined.count_rows()
-    # print(nrows)
-    # hgdp1kg_tobwgs_joined = filt_mt.sample_rows(1000000 / nrows, seed=12345)
+    nrows = hgdp1kg_tobwgs_joined.count_rows()
+    print(nrows)
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.sample_rows(
+        1000000 / nrows, seed=12345
+    )
 
     pruned_variant_table = hl.ld_prune(
         hgdp1kg_tobwgs_joined.GT, r2=0.1, bp_window_size=500000

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -58,7 +58,7 @@ def query(output):  # pylint: disable=too-many-locals
 
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.cache()
     nrows = hgdp1kg_tobwgs_joined.count_rows()
-    print(nrows)
+    print(f'hgdp1kg_tobwgs_joined.count_rows() = {nrows}')
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.sample_rows(
         1000000 / nrows, seed=12345
     )

--- a/scripts/hail_batch/variant_selection/main.py
+++ b/scripts/hail_batch/variant_selection/main.py
@@ -19,11 +19,10 @@ batch = hb.Batch(name='variant selection', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_tob_wgs_variant_selection.py --output={OUTPUT}',
-    max_age='5h',
-    num_secondary_workers=100,
+    max_age='12h',
+    num_secondary_workers=20,
     packages=['click'],
     job_name='variant-selection',
-    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
After speaking with Loic this morning and looking at the histogram plot output from `hgdp_1kg_tob_wgs_variant_selection_exploration.py`, we decided that increasing the variant allele frequency to 0.01, rather than 0.001, would reduce many of the variants while still keeping rare variants in the analysis. We also found that ld_prune removes around 90% of the variants (at least on the subset of 1M variants that we tested on). Therefore, to retain around 100K variants, I've sub-sampled the remaining variants after filtering to 1M, before LD-pruning. 

I tested this script first on the TOB-WGS data in the `test` bucket, which finished successfully. I've also taken the same parameters for the `dataproc.hail_dataproc_job` from the `ancestry/scripts/hail_batch/variant_selection_exploration/main.py` script and incorporated this into the `main.py` script.