### PR TITLE
Increase HDFS space by increasing worker_boot_disk_size

### DIFF
--- a/scripts/hail_batch/variant_selection/main.py
+++ b/scripts/hail_batch/variant_selection/main.py
@@ -23,6 +23,7 @@ dataproc.hail_dataproc_job(
     num_secondary_workers=20,
     packages=['click'],
     job_name='variant-selection',
+    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
My script failed with an error message of "File could only be replicated to 0 nodes instead of minReplication (=1)", which is likely due to HDFS running out of space. The GCP metrics explorer also confirmed that there was not enough HDFS space, so I increased this to 200.