### PR TITLE
Increase hdfs space for densified tob-wgs script

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca/main.py
@@ -23,6 +23,7 @@ dataproc.hail_dataproc_job(
     num_secondary_workers=20,
     packages=['click'],
     job_name=f'densify_tobwgs_pca',
+    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
I changed the `main.py` script for the wrong folder (variant_selection rather than hgdp1kg_tobwgs_densified_pca). As stated in the PR cf2fd4c, my script failed with the error "File could only be replicated to 0 nodes instead of minReplication (=1)", and the GCP metrics explorer confirmed this was due to running out of HDFS space. I now increased this to 200.