### PR TITLE
Repartition `hgdp1kg_tobwgs_joined` mt and remove worker_boot_disk_size

### DIFF
--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -72,8 +72,10 @@ def query(output):  # pylint: disable=too-many-locals
         hl.is_defined(pruned_variant_table[hgdp1kg_tobwgs_joined.row_key])
     )
     mt_path = f'{output}/tob_wgs_hgdp_1kg_filtered_variants.mt'
-    if not hl.hadoop_exists(mt_path):
-        hgdp1kg_tobwgs_joined.write(mt_path)
+    tmp_path = mt_path + '.tmp'
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.checkpoint(tmp_path)
+    hl.read_matrix_table(tmp_path, _n_partitions=100).write(mt_path)
+    hl.current_backend().fs.rmtree(tmp_path)
 
 
 if __name__ == '__main__':

--- a/scripts/hail_batch/variant_selection/main.py
+++ b/scripts/hail_batch/variant_selection/main.py
@@ -23,7 +23,6 @@ dataproc.hail_dataproc_job(
     num_secondary_workers=20,
     packages=['click'],
     job_name='variant-selection',
-    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
I repartitioned the `hgdp1kg_tobwgs_joined` matrix table to 100 partitions, as it is heavily filtered. I also incorrectly added `worker_boot_disk_size=200` in the `dataproc.hail_dataproc_job` function, and therefore am removing this.