### PR TITLE
Replace secondary workers with primary workers

### DIFF
--- a/scripts/hail_batch/variant_selection/README.md
+++ b/scripts/hail_batch/variant_selection/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to select a 
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "gs://cpg-tob-wgs-main/1kg_hgdp_ld_pruning/v0" \
---description "ld pruning" python3 main.py
+--access-level standard --output-dir "gs://cpg-tob-wgs-main/tob_wgs_hgdp_1kg_variant_selection/v3" \
+--description "variant selection" python3 main.py
 ```

--- a/scripts/hail_batch/variant_selection/main.py
+++ b/scripts/hail_batch/variant_selection/main.py
@@ -20,7 +20,7 @@ dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_tob_wgs_variant_selection.py --output={OUTPUT}',
     max_age='12h',
-    num_secondary_workers=20,
+    num_workers=50,
     packages=['click'],
     job_name='variant-selection',
 )


### PR DESCRIPTION
My last script failed with a [timeout error](https://batch.hail.populationgenomics.org.au/batches/2742/jobs/2), which is likely due to the repartitioning step of my code. Since I'm now repartitioning the`hgdp1kg_tobwgs_joined` matrix table using a shuffle, as suggested by [Tim Poterba on Zulip](https://hail.zulipchat.com/#narrow/stream/123010-Hail-0.2E2.20support/topic/How.20to.20choose.20number.20of.20partitions.20when.20repartitioning), I want to test whether this can be solved by using primary workers, rather than secondary workers. I chose 50, but this might need to be scaled down.