### PR TITLE
Generate PCA plots including html output

### DIFF
--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
@@ -1,18 +1,20 @@
 """Create PCA plots for HGDP/1kG + TOB-WGS samples"""
 
-from bokeh.models import CategoricalColorMapper
-from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
-from bokeh.io.export import get_screenshot_as_png
+# from bokeh.models import CategoricalColorMapper
+# from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
+
+# from bokeh.io.export import get_screenshot_as_png
+from bokeh.plotting import output_file, save
 import pandas as pd
 import hail as hl
 import click
 
 HGDP1KG_TOBWGS = (
-    'gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca/v2/'
-    'hgdp1kg_tobwgs_joined_all_samples.mt'
+    'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/'
+    'hgdp1kg_tobwgs_joined_all_samples.mt/'
 )
-SCORES = 'gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca/v2/scores.ht/'
-EIGENVALUES = 'gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca/v2/eigenvalues.ht/'
+SCORES = 'gs://cpg-tob-wgs-test/1kg_hgdp_densify/v15/scores.ht/'
+EIGENVALUES = 'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/eigenvalues.ht/'
 
 
 @click.command()
@@ -56,53 +58,54 @@ def query(output):  # pylint: disable=too-many-locals
             xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
             ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
         )
-        plot_filename = f'{output}/study_pc' + str(pc2) + '.png'
+        plot_filename = f'{output}/study_pc' + str(pc2) + '.html'
         with hl.hadoop_open(plot_filename, 'wb') as f:
-            get_screenshot_as_png(p).save(f, format='PNG')
+            output_file(f)
+            save(p)
 
-    print('Making PCA plots labelled by the continental population')
-    labels = columns.hgdp_1kg_metadata.population_inference.pop
-    pops = list(set(labels.collect()))
+    # print('Making PCA plots labelled by the continental population')
+    # labels = columns.hgdp_1kg_metadata.population_inference.pop
+    # pops = list(set(labels.collect()))
 
-    for i in range(0, (number_of_pcs - 1)):
-        pc1 = i
-        pc2 = i + 1
-        print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
-        p = hl.plot.scatter(
-            pca_scores[pc1],
-            pca_scores[pc2],
-            label=labels,
-            title='Continental Population',
-            xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
-            ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
-            collect_all=True,
-            colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
-        )
-        plot_filename = f'{output}/continental_population_pc' + str(pc2) + '.png'
-        with hl.hadoop_open(plot_filename, 'wb') as f:
-            get_screenshot_as_png(p).save(f, format='PNG')
+    # for i in range(0, (number_of_pcs - 1)):
+    #     pc1 = i
+    #     pc2 = i + 1
+    #     print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
+    #     p = hl.plot.scatter(
+    #         pca_scores[pc1],
+    #         pca_scores[pc2],
+    #         label=labels,
+    #         title='Continental Population',
+    #         xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
+    #         ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
+    #         collect_all=True,
+    #         colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
+    #     )
+    #     plot_filename = f'{output}/continental_population_pc' + str(pc2) + '.png'
+    #     with hl.hadoop_open(plot_filename, 'wb') as f:
+    #         get_screenshot_as_png(p).save(f, format='PNG')
 
-    print('Making PCA plots labelled by the subpopulation')
-    labels = columns.hgdp_1kg_metadata.labeled_subpop
-    pops = list(set(labels.collect()))
+    # print('Making PCA plots labelled by the subpopulation')
+    # labels = columns.hgdp_1kg_metadata.labeled_subpop
+    # pops = list(set(labels.collect()))
 
-    for i in range(0, (number_of_pcs - 1)):
-        pc1 = i
-        pc2 = i + 1
-        print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
-        p = hl.plot.scatter(
-            pca_scores[pc1],
-            pca_scores[pc2],
-            label=labels,
-            title='Sub-Population',
-            xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
-            ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
-            collect_all=True,
-            colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
-        )
-        plot_filename = f'{output}/subpopulation_pc' + str(pc2) + '.png'
-        with hl.hadoop_open(plot_filename, 'wb') as f:
-            get_screenshot_as_png(p).save(f, format='PNG')
+    # for i in range(0, (number_of_pcs - 1)):
+    #     pc1 = i
+    #     pc2 = i + 1
+    #     print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
+    #     p = hl.plot.scatter(
+    #         pca_scores[pc1],
+    #         pca_scores[pc2],
+    #         label=labels,
+    #         title='Sub-Population',
+    #         xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
+    #         ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
+    #         collect_all=True,
+    #         colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
+    #     )
+    #     plot_filename = f'{output}/subpopulation_pc' + str(pc2) + '.png'
+    #     with hl.hadoop_open(plot_filename, 'wb') as f:
+    #         get_screenshot_as_png(p).save(f, format='PNG')
 
 
 if __name__ == '__main__':

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
@@ -1,9 +1,8 @@
 """Create PCA plots for HGDP/1kG + TOB-WGS samples"""
 
-# from bokeh.models import CategoricalColorMapper
-# from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
-
 import subprocess
+from bokeh.models import CategoricalColorMapper
+from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
 from bokeh.io.export import get_screenshot_as_png
 from bokeh.plotting import output_file, save
 import pandas as pd
@@ -11,11 +10,11 @@ import hail as hl
 import click
 
 HGDP1KG_TOBWGS = (
-    'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/'
-    'hgdp1kg_tobwgs_joined_all_samples.mt/'
+    'gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca/v2/'
+    'hgdp1kg_tobwgs_joined_all_samples.mt'
 )
-SCORES = 'gs://cpg-tob-wgs-test/1kg_hgdp_densify/v15/scores.ht/'
-EIGENVALUES = 'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/eigenvalues.ht/'
+SCORES = 'gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca/v2/scores.ht/'
+EIGENVALUES = 'gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca/v2/eigenvalues.ht/'
 
 
 @click.command()
@@ -69,49 +68,58 @@ def query(output):  # pylint: disable=too-many-locals
         save(p)
         subprocess.run(['gsutil', 'cp', plot_filename_html, output], check=False)
 
-    # print('Making PCA plots labelled by the continental population')
-    # labels = columns.hgdp_1kg_metadata.population_inference.pop
-    # pops = list(set(labels.collect()))
+    print('Making PCA plots labelled by the continental population')
+    labels = columns.hgdp_1kg_metadata.population_inference.pop
+    pops = list(set(labels.collect()))
 
-    # for i in range(0, (number_of_pcs - 1)):
-    #     pc1 = i
-    #     pc2 = i + 1
-    #     print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
-    #     p = hl.plot.scatter(
-    #         pca_scores[pc1],
-    #         pca_scores[pc2],
-    #         label=labels,
-    #         title='Continental Population',
-    #         xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
-    #         ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
-    #         collect_all=True,
-    #         colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
-    #     )
-    #     plot_filename = f'{output}/continental_population_pc' + str(pc2) + '.png'
-    #     with hl.hadoop_open(plot_filename, 'wb') as f:
-    #         get_screenshot_as_png(p).save(f, format='PNG')
+    for i in range(0, (number_of_pcs - 1)):
+        pc1 = i
+        pc2 = i + 1
+        print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
+        p = hl.plot.scatter(
+            pca_scores[pc1],
+            pca_scores[pc2],
+            label=labels,
+            title='Continental Population',
+            xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
+            ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
+            collect_all=True,
+            colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
+            hover_fields=hover_fields,
+        )
+        plot_filename = f'{output}/continental_population_pc' + str(pc2) + '.png'
+        with hl.hadoop_open(plot_filename, 'wb') as f:
+            get_screenshot_as_png(p).save(f, format='PNG')
+        plot_filename_html = 'continental_population_pc' + str(pc2) + '.html'
+        output_file(plot_filename_html)
+        save(p)
+        subprocess.run(['gsutil', 'cp', plot_filename_html, output], check=False)
 
-    # print('Making PCA plots labelled by the subpopulation')
-    # labels = columns.hgdp_1kg_metadata.labeled_subpop
-    # pops = list(set(labels.collect()))
+    print('Making PCA plots labelled by the subpopulation')
+    labels = columns.hgdp_1kg_metadata.labeled_subpop
+    pops = list(set(labels.collect()))
 
-    # for i in range(0, (number_of_pcs - 1)):
-    #     pc1 = i
-    #     pc2 = i + 1
-    #     print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
-    #     p = hl.plot.scatter(
-    #         pca_scores[pc1],
-    #         pca_scores[pc2],
-    #         label=labels,
-    #         title='Sub-Population',
-    #         xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
-    #         ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
-    #         collect_all=True,
-    #         colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
-    #     )
-    #     plot_filename = f'{output}/subpopulation_pc' + str(pc2) + '.png'
-    #     with hl.hadoop_open(plot_filename, 'wb') as f:
-    #         get_screenshot_as_png(p).save(f, format='PNG')
+    for i in range(0, (number_of_pcs - 1)):
+        pc1 = i
+        pc2 = i + 1
+        print(f'PC{pc1 + 1} vs PC{pc2 + 1}')
+        p = hl.plot.scatter(
+            pca_scores[pc1],
+            pca_scores[pc2],
+            label=labels,
+            title='Sub-Population',
+            xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
+            ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
+            collect_all=True,
+            colors=CategoricalColorMapper(palette=turbo(len(pops)), factors=pops),
+        )
+        plot_filename = f'{output}/subpopulation_pc' + str(pc2) + '.png'
+        with hl.hadoop_open(plot_filename, 'wb') as f:
+            get_screenshot_as_png(p).save(f, format='PNG')
+        plot_filename_html = 'subpopulation_pc' + str(pc2) + '.html'
+        output_file(plot_filename_html)
+        save(p)
+        subprocess.run(['gsutil', 'cp', plot_filename_html, output], check=False)
 
 
 if __name__ == '__main__':

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
@@ -3,6 +3,7 @@
 # from bokeh.models import CategoricalColorMapper
 # from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
 
+import subprocess
 from bokeh.io.export import get_screenshot_as_png
 from bokeh.plotting import output_file, save
 import pandas as pd
@@ -61,8 +62,10 @@ def query(output):  # pylint: disable=too-many-locals
         plot_filename = f'{output}/study_pc' + str(pc2) + '.png'
         with hl.hadoop_open(plot_filename, 'wb') as f:
             get_screenshot_as_png(p).save(f, format='PNG')
-        output_file('study_pc' + str(pc2) + '.html')
+        plot_filename_html = 'study_pc' + str(pc2) + '.html'
+        output_file(plot_filename_html)
         save(p)
+        subprocess.run(['gsutil', 'cp', plot_filename_html, output], check=False)
 
     # print('Making PCA plots labelled by the continental population')
     # labels = columns.hgdp_1kg_metadata.population_inference.pop

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
@@ -18,8 +18,7 @@ EIGENVALUES = 'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/eigenvalues.ht/'
 
 
 @click.command()
-@click.option('--output', help='GCS output path', required=True)
-def query(output):  # pylint: disable=too-many-locals
+def query():  # pylint: disable=too-many-locals
     """Query script entry point."""
 
     hl.init()
@@ -58,7 +57,7 @@ def query(output):  # pylint: disable=too-many-locals
             xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
             ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
         )
-        plot_filename = f'{output}/study_pc' + str(pc2) + '.html'
+        plot_filename = 'study_pc' + str(pc2) + '.html'
         with hl.hadoop_open(plot_filename, 'wb'):
             output_file(plot_filename)
             save(p)

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
@@ -59,8 +59,8 @@ def query(output):  # pylint: disable=too-many-locals
             ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
         )
         plot_filename = f'{output}/study_pc' + str(pc2) + '.html'
-        with hl.hadoop_open(plot_filename, 'wb') as f:
-            output_file(f)
+        with hl.hadoop_open(plot_filename, 'wb'):
+            output_file(plot_filename)
             save(p)
 
     # print('Making PCA plots labelled by the continental population')

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
@@ -3,7 +3,7 @@
 # from bokeh.models import CategoricalColorMapper
 # from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
 
-# from bokeh.io.export import get_screenshot_as_png
+from bokeh.io.export import get_screenshot_as_png
 from bokeh.plotting import output_file, save
 import pandas as pd
 import hail as hl
@@ -18,7 +18,8 @@ EIGENVALUES = 'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/eigenvalues.ht/'
 
 
 @click.command()
-def query():  # pylint: disable=too-many-locals
+@click.option('--output', help='GCS output path', required=True)
+def query(output):  # pylint: disable=too-many-locals
     """Query script entry point."""
 
     hl.init()
@@ -57,10 +58,11 @@ def query():  # pylint: disable=too-many-locals
             xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
             ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
         )
-        plot_filename = 'study_pc' + str(pc2) + '.html'
-        with hl.hadoop_open(plot_filename, 'wb'):
-            output_file(plot_filename)
-            save(p)
+        plot_filename = f'{output}/study_pc' + str(pc2) + '.png'
+        with hl.hadoop_open(plot_filename, 'wb') as f:
+            get_screenshot_as_png(p).save(f, format='PNG')
+        output_file('study_pc' + str(pc2) + '.html')
+        save(p)
 
     # print('Making PCA plots labelled by the continental population')
     # labels = columns.hgdp_1kg_metadata.population_inference.pop

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_all_samples/hgdp_1kg_tob_wgs_plot_pca_all_samples.py
@@ -34,6 +34,7 @@ def query(output):  # pylint: disable=too-many-locals
     columns = mt.cols()
     pca_scores = columns.scores
     labels = columns.TOB_WGS
+    hover_fields = dict([('s', columns.s)])
 
     # get percent variance explained
     eigenvalues = hl.import_table(EIGENVALUES)
@@ -58,6 +59,7 @@ def query(output):  # pylint: disable=too-many-locals
             title='TOB-WGS',
             xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
             ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc2]) + '%)',
+            hover_fields=hover_fields,
         )
         plot_filename = f'{output}/study_pc' + str(pc2) + '.png'
         with hl.hadoop_open(plot_filename, 'wb') as f:


### PR DESCRIPTION
Generate PCA plots of all combined HGDP/1kG + TOB-WGS samples and include HTML output, as well as png output in the `web` bucket. HTML output is useful, as it allows for viewing sample names and attributes of individual points within the PCA.