### PR TITLE
Increase the number of partitions from 100 to 1000

### DIFF
--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -72,10 +72,12 @@ def query(output):  # pylint: disable=too-many-locals
         hl.is_defined(pruned_variant_table[hgdp1kg_tobwgs_joined.row_key])
     )
     mt_path = f'{output}/tob_wgs_hgdp_1kg_filtered_variants.mt'
-    tmp_path = mt_path + '.tmp'
+    tmp_path = (
+        'gs://cpg-tob-wgs-main-tmp/tob_wgs_hgdp_1kg_variant_selection/'
+        'tob_wgs_hgdp_1kg_filtered_variants.mt.tmp'
+    )
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.checkpoint(tmp_path)
-    hl.read_matrix_table(tmp_path, _n_partitions=100).write(mt_path)
-    hl.current_backend().fs.rmtree(tmp_path)
+    hl.read_matrix_table(tmp_path, _n_partitions=1000).write(mt_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Since our previous script failed with a timeout, I'm testing repartitioning using 1000 partitions. I've alse saved the tmp file to the `cpg-tob-wgs-main-tmp` bucket.