### PR TITLE
Add plotting command inside of for loop

### DIFF
--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_nfe_loadings/README.md
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_nfe_loadings/README.md
@@ -1,9 +1,9 @@
-# Plot PCA of densified PCA on NFE samples
+# Plot PCA loadings of densified PCA on NFE samples
 
 This runs a Hail query script in Dataproc using Hail Batch in order to plot the output of the PCA loadings on nfe samples only, generated from the script `hgdp_1kg_tob_wgs_densified_pca.py`. To run, use conda to install the analysis-runner, then execute the following command:
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "gs://cpg-tob-wgs-main/tob_wgs_hgdp_1kg_nfe_pca_densified/v0" \
+--access-level standard --output-dir "gs://cpg-tob-wgs-main-web/tob_wgs_hgdp_1kg_nfe_pca_densified/v3" \
 --description "densified pca loadings nfe" python3 main.py
 ```

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_nfe_loadings/hgdp_1kg_tob_wgs_plot_loadings_nfe.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pop_pca_densified_nfe_loadings/hgdp_1kg_tob_wgs_plot_loadings_nfe.py
@@ -120,13 +120,13 @@ def query(output):  # pylint: disable=too-many-locals
             title='Loadings of PC ' + str(pc),
             collect_all=True,
         )
-    plot_filename = f'{output}/loadings_manhattan_plot_pc' + str(pc) + '.png'
-    with hl.hadoop_open(plot_filename, 'wb') as f:
-        get_screenshot_as_png(p).save(f, format='PNG')
-    plot_filename_html = 'loadings_pc' + str(pc) + '.html'
-    output_file(plot_filename_html)
-    save(p)
-    subprocess.run(['gsutil', 'cp', plot_filename_html, output], check=False)
+        plot_filename = f'{output}/loadings_manhattan_plot_pc' + str(pc) + '.png'
+        with hl.hadoop_open(plot_filename, 'wb') as f:
+            get_screenshot_as_png(p).save(f, format='PNG')
+        plot_filename_html = 'loadings_pc' + str(pc) + '.html'
+        output_file(plot_filename_html)
+        save(p)
+        subprocess.run(['gsutil', 'cp', plot_filename_html, output], check=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I accidentally put the plotting command outside of the for loop, so now it's contained inside and should save every single pc loadings plot, rather than just the one. I've also updated the path in the README file, whie was `gs://cpg-tob-wgs-main` rather than `gs://cpg-tob-wgs-main-web`