### PR TITLE
Increase glyph transparency when plotting

### DIFF
--- a/scripts/plotting/reprocessed_gatk4_samples_pca/project_reprocessed_gatk4_samples.py
+++ b/scripts/plotting/reprocessed_gatk4_samples_pca/project_reprocessed_gatk4_samples.py
@@ -3,14 +3,17 @@ Perform PCA on the three 1kG samples,
 reprocessed using the GATK4 pipeline.
 """
 
+import subprocess
 import click
 import pandas as pd
 import hail as hl
 from hail.experimental import lgt_to_gt
 from hail.experimental import pc_project
-from bokeh.models import CategoricalColorMapper
-from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
+from bokeh.palettes import Dark2  # pylint: disable=no-name-in-module
 from bokeh.io.export import get_screenshot_as_png
+from bokeh.plotting import output_file, save, ColumnDataSource, figure
+from bokeh.transform import factor_cmap
+
 
 HGDP1KG_TOBWGS = (
     'gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca/v2/'
@@ -87,6 +90,7 @@ def query(output, pop):  # pylint: disable=too-many-locals
     # plot
     labels = union_scores.cohort_sample_codes
     cohort_sample_codes = list(set(labels.collect()))
+    tooltips = [('labels', '@label')]
     for i in range(0, 10):
         pc1 = i
         pc2 = i + 1
@@ -94,19 +98,39 @@ def query(output, pop):  # pylint: disable=too-many-locals
             f'{output}/reprocessed_sample_projection_pc' + str(i + 1) + '.png'
         )
         if not hl.hadoop_exists(plot_filename):
-            plot = hl.plot.scatter(
-                union_scores.scores[pc1],
-                union_scores.scores[pc2],
-                label=labels,
+            plot = figure(
                 title='Reprocessed Sample Projection',
-                xlabel='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
-                ylabel='PC' + str(pc2 + 1) + ' (' + str(variance[pc1]) + '%)',
-                colors=CategoricalColorMapper(
-                    palette=turbo(len(cohort_sample_codes)), factors=cohort_sample_codes
-                ),
+                x_axis_label='PC' + str(pc1 + 1) + ' (' + str(variance[pc1]) + '%)',
+                y_axis_label='PC' + str(pc2 + 1) + ' (' + str(variance[pc1]) + '%)',
+                tooltips=tooltips,
             )
+            source = ColumnDataSource(
+                dict(
+                    x=union_scores.scores[pc1].collect(),
+                    y=union_scores.scores[pc2].collect(),
+                    label=labels.collect(),
+                )
+            )
+            plot.circle(
+                'x',
+                'y',
+                alpha=0.5,
+                source=source,
+                size=8,
+                color=factor_cmap(
+                    'label', Dark2[len(cohort_sample_codes)], cohort_sample_codes
+                ),
+                legend_group='label',
+            )
+            plot.add_layout(plot.legend[0], 'left')
             with hl.hadoop_open(plot_filename, 'wb') as f:
                 get_screenshot_as_png(plot).save(f, format='PNG')
+            plot_filename_html = (
+                'reprocessed_sample_projection_pc' + str(i + 1) + '.html'
+            )
+            output_file(plot_filename_html)
+            save(plot)
+            subprocess.run(['gsutil', 'cp', plot_filename_html, output], check=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I can't actually see the points in my plot because the circle glyphs are not opaque. I tried finding a simple way to do this using `hl.plot.scatter()`, but unfortunately I couldn't find anything helpful within the documentation. The best solution I could find is setting up a basic plotting space using `plot`, then projecting the glyphs onto that space using the coordinates from the pca scores (as done originally, just with `hl.plot.scatter`).