### PR TITLE
Remove tmp file and repartition as in `hgdp_1kg_tob_wgs_densify.py`

### DIFF
--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -26,9 +26,6 @@ def query(output):  # pylint: disable=too-many-locals
 
     # filter to loci that are contained in both matrix tables after densifying
     tob_wgs = hl.experimental.densify(tob_wgs)
-    hgdp_1kg = hgdp_1kg.filter_rows(
-        hl.is_defined(tob_wgs.index_rows(hgdp_1kg['locus'], hgdp_1kg['alleles']))
-    )
     tob_wgs = tob_wgs.semi_join_rows(hgdp_1kg.rows())
 
     # Entries and columns must be identical

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -26,7 +26,6 @@ def query(output):  # pylint: disable=too-many-locals
 
     # filter to loci that are contained in both matrix tables after densifying
     tob_wgs = hl.experimental.densify(tob_wgs)
-    tob_wgs = tob_wgs.semi_join_rows(hgdp_1kg.rows())
 
     # Entries and columns must be identical
     tob_wgs_select = tob_wgs.select_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))

--- a/scripts/hail_batch/variant_selection/main.py
+++ b/scripts/hail_batch/variant_selection/main.py
@@ -20,7 +20,7 @@ dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_tob_wgs_variant_selection.py --output={OUTPUT}',
     max_age='12h',
-    num_workers=20,
+    num_secondary_workers=20,
     packages=['click'],
     job_name='variant-selection',
 )


### PR DESCRIPTION
I removed the temporary path and checkpoint and instead repartitioned using the same method we used in `hgdp_1kg_tob_wgs_densify.py`, which completed successfully.  I've also printed out the number of rows in the pruned variant table, so that we get a better idea of where the code is breaking if it fails. 