### PR TITLE
Reduce number of input variants for LD prune and remove caching

### DIFF
--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -64,7 +64,6 @@ def query(output):  # pylint: disable=too-many-locals
     pruned_variant_table = hl.ld_prune(
         hgdp1kg_tobwgs_joined.GT, r2=0.1, bp_window_size=500000
     )
-    pruned_variant_table = pruned_variant_table.cache()
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.filter_rows(
         hl.is_defined(pruned_variant_table[hgdp1kg_tobwgs_joined.row_key])
     )

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -11,7 +11,7 @@ GNOMAD_HGDP_1KG_MT = (
 
 TOB_WGS = 'gs://cpg-tob-wgs-main/mt/v2-raw.mt/'
 
-NUM_ROWS_BEFORE_LD_PRUNE = 500000
+NUM_ROWS_BEFORE_LD_PRUNE = 200000
 
 
 @click.command()

--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -11,7 +11,7 @@ GNOMAD_HGDP_1KG_MT = (
 
 TOB_WGS = 'gs://cpg-tob-wgs-main/mt/v2-raw.mt/'
 
-NUM_ROWS_BEFORE_LD_PRUNE = 1000000
+NUM_ROWS_BEFORE_LD_PRUNE = 500000
 
 
 @click.command()
@@ -65,8 +65,6 @@ def query(output):  # pylint: disable=too-many-locals
         hgdp1kg_tobwgs_joined.GT, r2=0.1, bp_window_size=500000
     )
     pruned_variant_table = pruned_variant_table.cache()
-    nrows = pruned_variant_table.count_rows()
-    print(f'pruned_variant_table.count_rows() = {nrows}')
     hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.filter_rows(
         hl.is_defined(pruned_variant_table[hgdp1kg_tobwgs_joined.row_key])
     )


### PR DESCRIPTION
My script [failed ](https://batch.hail.populationgenomics.org.au/batches/3052/jobs/2) with an error `Cannot change storage level of an RDD after it was already assigned a level at org.apache.spark.rdd.RDD.persist(RDD.scala:170)`. I searched what this error may be due to and it looks like it might be caused by persisting the `pruned_variant_table` into memory, as it may already be persisted into memory (as suggested [here](https://stackoverflow.com/questions/37750545/cannot-change-storage-level-of-rdd)). I also got the warning `WARN: over 400,000 edges are in the graph; maximal_independent_set may run out of memory`, suggesting that I just have too many input variants into `ld_prune`. Although the total output variants will be less, I'm curious if ld_prune can actually handle so many variants, so I've reduced this number to 500k, rather than 1M.