### PR TITLE
Delete repartitioning step after ld-prune

### DIFF
--- a/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
+++ b/scripts/hail_batch/variant_selection/hgdp_1kg_tob_wgs_variant_selection.py
@@ -68,7 +68,6 @@ def query(output):  # pylint: disable=too-many-locals
         hl.is_defined(pruned_variant_table[hgdp1kg_tobwgs_joined.row_key])
     )
     mt_path = f'{output}/tob_wgs_hgdp_1kg_filtered_variants.mt'
-    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.repartition(1000, shuffle=False)
     hgdp1kg_tobwgs_joined.write(mt_path)
 
 


### PR DESCRIPTION
My script failed again, even after reducing the number of variants into ld-prune and trying several differnet ways to save my reprtitioned table. To test whether this issue is due to repartitioning (which it likely is), I'm omitting the repartitioning step, but will ask in Zulip what the best way forward is for repartitioning tables after heavy filtering.