### PR TITLE
Reorder `select_entries` and `select_cols` fields

### DIFF
--- a/scripts/hail_batch/snp_chip_generate_pca/snp_chip_generate_pca.py
+++ b/scripts/hail_batch/snp_chip_generate_pca/snp_chip_generate_pca.py
@@ -23,10 +23,10 @@ def query(output):  # pylint: disable=too-many-locals
 
     # filter to loci that are contained in snp-chip data after densifying
     tob_wgs = hl.experimental.densify(tob_wgs)
-    tob_wgs = tob_wgs.select_cols().select_entries(
+    tob_wgs = tob_wgs.select_entries(
         GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA)
-    )
-    snp_chip = snp_chip.select_cols().select_entries(snp_chip.GT)
+    ).select_cols()
+    snp_chip = snp_chip.select_entries(snp_chip.GT).select_cols()
     tob_combined = tob_wgs.union_cols(snp_chip)
     tob_combined = tob_combined.cache()
     print(tob_combined.count_rows())


### PR DESCRIPTION
The ordering of `select_entries` and `select_cols` seems to matter when assigning `lgt_to_gt(tob_wgs.LGT, tob_wgs.LA)` to `GT` (the error can be seen [here](https://batch.hail.populationgenomics.org.au/batches/3104/jobs/2)). I've now rearranged these and tested the whole script on `gs://cpg-tob-wgs-test/mt/v2-raw.mt/` instead of `gs://cpg-tob-wgs-test/mt/v3.mt/`, since the `LGT` field is present in the former file.