### PR TITLE
Update output paths after updated analysis runner version

### DIFF
--- a/scripts/hail_batch/snp_chip_generate_pca/README.md
+++ b/scripts/hail_batch/snp_chip_generate_pca/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to generate 
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "gs://cpg-tob-wgs-main/tob_wgs_snp_chip_variant_pca/v0" \
+--access-level standard --output-dir "tob_wgs_snp_chip_variant_pca/v0" \
 --description "snp chip variants pca" python3 main.py
 ```

--- a/scripts/hail_batch/snp_chip_generate_pca/main.py
+++ b/scripts/hail_batch/snp_chip_generate_pca/main.py
@@ -1,14 +1,9 @@
 """Entry point for the analysis runner."""
 
 import os
-import hail as hl
 import hailtop.batch as hb
 from analysis_runner import dataproc
 
-OUTPUT = os.getenv('OUTPUT')
-assert OUTPUT
-
-hl.init(default_reference='GRCh38')
 
 service_backend = hb.ServiceBackend(
     billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
@@ -18,7 +13,7 @@ batch = hb.Batch(name=f'snp_chip_variants_pca', backend=service_backend)
 
 dataproc.hail_dataproc_job(
     batch,
-    f'snp_chip_generate_pca.py --output={OUTPUT}',
+    'snp_chip_generate_pca.py',
     max_age='12h',
     num_secondary_workers=20,
     packages=['click'],

--- a/scripts/hail_batch/snp_chip_generate_pca/main.py
+++ b/scripts/hail_batch/snp_chip_generate_pca/main.py
@@ -17,6 +17,7 @@ dataproc.hail_dataproc_job(
     max_age='12h',
     num_secondary_workers=20,
     packages=['click'],
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name=f'snp_chip_variants_pca',
 )
 

--- a/scripts/hail_batch/snp_chip_generate_pca/snp_chip_generate_pca.py
+++ b/scripts/hail_batch/snp_chip_generate_pca/snp_chip_generate_pca.py
@@ -6,14 +6,15 @@ import click
 import hail as hl
 import pandas as pd
 from hail.experimental import lgt_to_gt
+from analysis_runner import output_path
 
-TOB_WGS = 'gs://cpg-tob-wgs-main/mt/v3-raw.mt/'
+# TOB_WGS = 'gs://cpg-tob-wgs-main/mt/v3-raw.mt/'
+TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v2-raw.mt/'
 SNP_CHIP = 'gs://cpg-tob-wgs-test/snpchip/v1/snpchip_grch38.mt/'
 
 
 @click.command()
-@click.option('--output', help='GCS output path', required=True)
-def query(output):  # pylint: disable=too-many-locals
+def query():  # pylint: disable=too-many-locals
     """Query script entry point."""
 
     hl.init(default_reference='GRCh38')
@@ -23,6 +24,7 @@ def query(output):  # pylint: disable=too-many-locals
 
     # filter to loci that are contained in snp-chip data after densifying
     tob_wgs = hl.experimental.densify(tob_wgs)
+    tob_wgs = tob_wgs.head(500000)
     tob_wgs = tob_wgs.select_entries(
         GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA)
     ).select_cols()
@@ -33,9 +35,9 @@ def query(output):  # pylint: disable=too-many-locals
     print(tob_combined.count_rows())
 
     # Perform PCA
-    eigenvalues_path = f'{output}/eigenvalues.ht'
-    scores_path = f'{output}/scores.ht'
-    loadings_path = f'{output}/loadings.ht'
+    eigenvalues_path = output_path('eigenvalues.ht')
+    scores_path = output_path('scores.ht')
+    loadings_path = output_path('loadings.ht')
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(
         tob_combined.GT, compute_loadings=True, k=20
     )

--- a/scripts/hail_batch/snp_chip_generate_pca/snp_chip_generate_pca.py
+++ b/scripts/hail_batch/snp_chip_generate_pca/snp_chip_generate_pca.py
@@ -8,8 +8,7 @@ import pandas as pd
 from hail.experimental import lgt_to_gt
 from analysis_runner import output_path
 
-# TOB_WGS = 'gs://cpg-tob-wgs-main/mt/v3-raw.mt/'
-TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v2-raw.mt/'
+TOB_WGS = 'gs://cpg-tob-wgs-main/mt/v3-raw.mt/'
 SNP_CHIP = 'gs://cpg-tob-wgs-test/snpchip/v1/snpchip_grch38.mt/'
 
 
@@ -24,7 +23,6 @@ def query():  # pylint: disable=too-many-locals
 
     # filter to loci that are contained in snp-chip data after densifying
     tob_wgs = hl.experimental.densify(tob_wgs)
-    tob_wgs = tob_wgs.head(500000)
     tob_wgs = tob_wgs.select_entries(
         GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA)
     ).select_cols()


### PR DESCRIPTION
I updated the way my output is constructed by using `output_path(filename)` rather than `f'{output}/filename`. I also updated the init script to `install_common` and did a test run beforehand to make sure everything is working after the new analysis runner update. 