### PR TITLE
Increase bin size

### DIFF
--- a/scripts/plotting/variant_selection_qc_histogram/variant_selection_qc_histogram.py
+++ b/scripts/plotting/variant_selection_qc_histogram/variant_selection_qc_histogram.py
@@ -10,13 +10,8 @@ from bokeh.io.export import get_screenshot_as_png
 from bokeh.resources import CDN
 from bokeh.embed import file_html
 
-# FILTERED_VARIANTS = bucket_path(
-#  'tob_wgs_hgdp_1kg_variant_selection/v8/'
-#  'tob_wgs_hgdp_1kg_filtered_variants.mt'
-# )
-
 FILTERED_VARIANTS = bucket_path(
-    '1kg_hgdp_tobwgs_pca/v1/hgdp1kg_tobwgs_joined_all_samples.mt/'
+    'tob_wgs_hgdp_1kg_variant_selection/v8/tob_wgs_hgdp_1kg_filtered_variants.mt'
 )
 
 
@@ -27,8 +22,6 @@ def query():  # pylint: disable=too-many-locals
     hl.init(default_reference='GRCh38')
 
     mt = hl.read_matrix_table(FILTERED_VARIANTS)
-    mt = mt.head(1000)
-    mt = hl.variant_qc(mt)
     nrows = mt.count_rows()
     print(f'mt.count_rows() = {nrows}')
 

--- a/scripts/plotting/variant_selection_qc_histogram/variant_selection_qc_histogram.py
+++ b/scripts/plotting/variant_selection_qc_histogram/variant_selection_qc_histogram.py
@@ -10,8 +10,14 @@ from bokeh.io.export import get_screenshot_as_png
 from bokeh.resources import CDN
 from bokeh.embed import file_html
 
+# FILTERED_VARIANTS = bucket_path(
+#  'tob_wgs_hgdp_1kg_variant_selection/v8/'
+#  'tob_wgs_hgdp_1kg_filtered_variants.mt'
+# )
+
 FILTERED_VARIANTS = bucket_path(
-    'tob_wgs_hgdp_1kg_variant_selection/v8/' 'tob_wgs_hgdp_1kg_filtered_variants.mt'
+    'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/'
+    'hgdp1kg_tobwgs_joined_all_samples.mt/'
 )
 
 
@@ -22,6 +28,8 @@ def query():  # pylint: disable=too-many-locals
     hl.init(default_reference='GRCh38')
 
     mt = hl.read_matrix_table(FILTERED_VARIANTS)
+    mt = mt.head(1000)
+    mt = hl.variant_qc(mt)
     nrows = mt.count_rows()
     print(f'mt.count_rows() = {nrows}')
 
@@ -33,7 +41,7 @@ def query():  # pylint: disable=too-many-locals
     )
     variant_af = mt.variant_qc.AF[1].collect()
     af_count, edges = np.histogram(
-        variant_af, weights=np.ones(len(variant_af)) / len(variant_af)
+        variant_af, bins=100, weights=np.ones(len(variant_af)) / len(variant_af)
     )
     variant_af_count = pd.DataFrame(
         {'variant_af_count': af_count, 'left': edges[:-1], 'right': edges[1:]}

--- a/scripts/plotting/variant_selection_qc_histogram/variant_selection_qc_histogram.py
+++ b/scripts/plotting/variant_selection_qc_histogram/variant_selection_qc_histogram.py
@@ -16,8 +16,7 @@ from bokeh.embed import file_html
 # )
 
 FILTERED_VARIANTS = bucket_path(
-    'gs://cpg-tob-wgs-test/1kg_hgdp_tobwgs_pca/v1/'
-    'hgdp1kg_tobwgs_joined_all_samples.mt/'
+    '1kg_hgdp_tobwgs_pca/v1/hgdp1kg_tobwgs_joined_all_samples.mt/'
 )
 
 


### PR DESCRIPTION
My [variant selection script](https://main-web.populationgenomics.org.au/tob-wgs/tob_wgs_hgdp_1kg_variant_selection/v0/variant_selection_histogram.html) worked! However, the bins are a bit too large (the default is 10 bins), so I want to see the allele frequency at a more granular level. I've therefore increased the bin size to 100. 