### PR TITLE
Perform PCA on SNP-chip data only

### DIFF
--- a/scripts/hail_batch/snp_chip_pca_sanity_check/README.md
+++ b/scripts/hail_batch/snp_chip_pca_sanity_check/README.md
@@ -1,0 +1,9 @@
+# Generate PCA of SNP-chip data only
+
+This runs a Hail query script in Dataproc using Hail Batch in order to generate a PCA of the TOB SNP-chip data. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "tob_snp_chip_pca/v0" \
+--description "snp chip only pca" python3 main.py
+```

--- a/scripts/hail_batch/snp_chip_pca_sanity_check/main.py
+++ b/scripts/hail_batch/snp_chip_pca_sanity_check/main.py
@@ -1,0 +1,23 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name=f'snp_chip_only_pca', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    'snp_chip_only_generate_pca.py',
+    max_age='12h',
+    num_secondary_workers=20,
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    job_name=f'snp_chip_only_pca',
+)
+
+batch.run()

--- a/scripts/hail_batch/snp_chip_pca_sanity_check/snp_chip_only_generate_pca.py
+++ b/scripts/hail_batch/snp_chip_pca_sanity_check/snp_chip_only_generate_pca.py
@@ -1,0 +1,34 @@
+"""
+Generate PCA on SNP-chip data only.
+"""
+
+import click
+import hail as hl
+import pandas as pd
+from analysis_runner import bucket_path, output_path
+
+SNP_CHIP = bucket_path('snpchip/v1/snpchip_grch38.mt')
+
+
+@click.command()
+def query():
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    snp_chip = hl.read_matrix_table(SNP_CHIP)
+    snp_chip = snp_chip.head(1000)
+    eigenvalues_path = output_path('eigenvalues.ht')
+    scores_path = output_path('scores.ht')
+    loadings_path = output_path('loadings.ht')
+    # Perform PCA
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(
+        snp_chip.GT, compute_loadings=True, k=5
+    )
+    hl.Table.from_pandas(pd.DataFrame(eigenvalues)).export(eigenvalues_path)
+    scores.write(scores_path, overwrite=True)
+    loadings.write(loadings_path, overwrite=True)
+
+
+if __name__ == '__main__':
+    query()

--- a/scripts/hail_batch/snp_chip_pca_sanity_check/snp_chip_only_generate_pca.py
+++ b/scripts/hail_batch/snp_chip_pca_sanity_check/snp_chip_only_generate_pca.py
@@ -17,7 +17,6 @@ def query():
     hl.init(default_reference='GRCh38')
 
     snp_chip = hl.read_matrix_table(SNP_CHIP)
-    snp_chip = snp_chip.head(1000)
     eigenvalues_path = output_path('eigenvalues.ht')
     scores_path = output_path('scores.ht')
     loadings_path = output_path('loadings.ht')


### PR DESCRIPTION
Generate PCA of SNP chip samples only after [successfully running](https://batch.hail.populationgenomics.org.au/batches/3430/jobs/2) in the`test` bucket. 