### PR TITLE
Increase the number of partitions in SNP-chip dataset to 100 

### DIFF
--- a/scripts/hail_batch/increase_snp_chip_partitions/README.md
+++ b/scripts/hail_batch/increase_snp_chip_partitions/README.md
@@ -1,0 +1,9 @@
+# Project WGS samples onto SNP-chip PCA
+
+This runs a Hail query script in Dataproc using Hail Batch in order to increase the number of partitions in the SNP-chip matrix table. Since the matrix table currently only has one partition, this results in a high amount of work done using once process only. This is particularly difficult when intersecting with another matrix table that has many partitions. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "tob_wgs_snp_chip_pca/increase_partitions/v0" \
+--description "increase partitions snp-chip" python3 main.py
+```

--- a/scripts/hail_batch/increase_snp_chip_partitions/README.md
+++ b/scripts/hail_batch/increase_snp_chip_partitions/README.md
@@ -1,6 +1,6 @@
 # Project WGS samples onto SNP-chip PCA
 
-This runs a Hail query script in Dataproc using Hail Batch in order to increase the number of partitions in the SNP-chip matrix table. Since the matrix table currently only has one partition, this results in a high amount of work done using once process only. This is particularly difficult when intersecting with another matrix table that has many partitions. To run, use conda to install the analysis-runner, then execute the following command:
+This runs a Hail query script in Dataproc using Hail Batch in order to increase the number of partitions in the SNP-chip matrix table. Since the matrix table currently only has one partition, this results in a high amount of work done using one worker only. This is particularly difficult when intersecting with another matrix table that has many partitions. To run, use conda to install the analysis-runner, then execute the following command:
 
 ```sh
 analysis-runner --dataset tob-wgs \

--- a/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
@@ -1,6 +1,5 @@
 """
-Increase the number of partitions
-in the SNP-Chip dataset.
+Increase the number of partitions in the SNP-Chip dataset.
 """
 
 import hail as hl

--- a/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
@@ -14,8 +14,6 @@ def query():
     hl.init(default_reference='GRCh38')
 
     snp_chip = hl.read_matrix_table(SNP_CHIP).key_rows_by('locus', 'alleles')
-    tob_wgs = hl.read_matrix_table(TOB_WGS)
-    snp_chip = snp_chip.semi_join_rows(tob_wgs.rows())
     snp_chip = snp_chip.repartition(100)
     snp_chip_path = output_path('snp_chip_100_partitions.mt')
     snp_chip.write(snp_chip_path, overwrite=True)

--- a/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
@@ -1,0 +1,28 @@
+"""
+Increase the number of partitions
+in the SNP-Chip dataset.
+"""
+
+import hail as hl
+from analysis_runner import bucket_path, output_path
+
+SNP_CHIP = bucket_path('snpchip/v1/snpchip_grch38.mt')
+# TOB_WGS = bucket_path('mt/v3-raw.mt')
+TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v4.mt/'
+
+
+def query():
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    snp_chip = hl.read_matrix_table(SNP_CHIP).key_rows_by('locus', 'alleles')
+    tob_wgs = hl.read_matrix_table(TOB_WGS)
+    snp_chip = snp_chip.semi_join_rows(tob_wgs.rows())
+    snp_chip = snp_chip.repartition(100)
+    snp_chip_path = output_path('snp_chip_100_partitions.mt')
+    snp_chip.write(snp_chip_path, overwrite=True)
+
+
+if __name__ == '__main__':
+    query()

--- a/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
@@ -7,8 +7,7 @@ import hail as hl
 from analysis_runner import bucket_path, output_path
 
 SNP_CHIP = bucket_path('snpchip/v1/snpchip_grch38.mt')
-# TOB_WGS = bucket_path('mt/v3-raw.mt')
-TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v4.mt/'
+TOB_WGS = bucket_path('mt/v3-raw.mt')
 
 
 def query():

--- a/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
@@ -6,7 +6,6 @@ import hail as hl
 from analysis_runner import bucket_path, output_path
 
 SNP_CHIP = bucket_path('snpchip/v1/snpchip_grch38.mt')
-TOB_WGS = bucket_path('mt/v3-raw.mt')
 
 
 def query():

--- a/scripts/hail_batch/increase_snp_chip_partitions/main.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/main.py
@@ -1,0 +1,23 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name=f'increase_partitions', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    'project_wgs_samples_onto_snp_chip.py',
+    max_age='2h',
+    num_workers=20,
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    job_name=f'increase_partitions',
+)
+
+batch.run()

--- a/scripts/hail_batch/increase_snp_chip_partitions/main.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/main.py
@@ -13,7 +13,7 @@ batch = hb.Batch(name=f'increase_partitions', backend=service_backend)
 
 dataproc.hail_dataproc_job(
     batch,
-    'project_wgs_samples_onto_snp_chip.py',
+    'increase_snp_chip_partitions.py',
     max_age='2h',
     num_workers=20,
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],


### PR DESCRIPTION
Since the SNP-chip matrix table currently only has one partition, this becomes problematic when intersecting with a large matrix table with many partitions. I've therefore increased the total number of partitions in order to better parallelise the data.