### PR TITLE
Project WGS data onto repartitioned mt

### DIFF
--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/README.md
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/README.md
@@ -1,9 +1,9 @@
 # Project WGS samples onto SNP-chip PCA
 
-This runs a Hail query script in Dataproc using Hail Batch in order to generate a PCA of the TOB SNP-chip data, then project the WGS samples onto it. To run, use conda to install the analysis-runner, then execute the following command:
+This runs a Hail query script in Dataproc using Hail Batch in order to generate a PCA of the TOB SNP-chip data, then project the WGS samples onto it. The TOB SNP-chip data was first repartitioned in `increase_snp_chip_partitions/increase_snp_chip_partitions.py`. To run, use conda to install the analysis-runner, then execute the following command:
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "tob_wgs_snp_chip_pca/v2" \
---description "project wgs smaples" python3 main.py
+--access-level standard --output-dir "tob_wgs_snp_chip_pca/v0" \
+--description "project wgs samples" python3 main.py
 ```

--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
@@ -14,8 +14,11 @@ from bokeh.resources import CDN
 from bokeh.embed import file_html
 from bokeh.io.export import get_screenshot_as_png
 
-SNP_CHIP = bucket_path('snpchip/v1/snpchip_grch38.mt')
-TOB_WGS = bucket_path('mt/v3-raw.mt')
+SNP_CHIP = bucket_path(
+    'tob_wgs_snp_chip_pca/increase_partitions/v0/snp_chip_100_partitions.mt'
+)
+# TOB_WGS = bucket_path('mt/v3-raw.mt')
+TOB_WGS = bucket_path('mt/v4.mt')
 
 
 def query():
@@ -23,8 +26,9 @@ def query():
 
     hl.init(default_reference='GRCh38')
 
-    snp_chip = hl.read_matrix_table(SNP_CHIP).key_rows_by('locus', 'alleles')
+    snp_chip = hl.read_matrix_table(SNP_CHIP)
     tob_wgs = hl.read_matrix_table(TOB_WGS)
+    tob_wgs = tob_wgs.head(1000000)
     tob_wgs = hl.experimental.densify(tob_wgs)
     tob_wgs = tob_wgs.annotate_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))
 

--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
@@ -17,8 +17,7 @@ from bokeh.io.export import get_screenshot_as_png
 SNP_CHIP = bucket_path(
     'tob_wgs_snp_chip_pca/increase_partitions/v0/snp_chip_100_partitions.mt'
 )
-# TOB_WGS = bucket_path('mt/v3-raw.mt')
-TOB_WGS = bucket_path('mt/v4.mt')
+TOB_WGS = bucket_path('mt/v3-raw.mt')
 
 
 def query():
@@ -28,7 +27,6 @@ def query():
 
     snp_chip = hl.read_matrix_table(SNP_CHIP)
     tob_wgs = hl.read_matrix_table(TOB_WGS)
-    tob_wgs = tob_wgs.head(1000000)
     tob_wgs = hl.experimental.densify(tob_wgs)
     tob_wgs = tob_wgs.annotate_entries(GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA))
 


### PR DESCRIPTION
My initial script didn't successfully complete after 12 hours of runtime, and this is likely due to the SNP-chip matrix table only having one partition (i.e., relying on one worker after intersecting with the much larger TOB-WGS dataset). I'm therefore re-testing this script after increasing the number of partitions in the SNP-chip dataset (done [here](https://github.com/populationgenomics/ancestry/blob/main/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py). 