### PR TITLE
Increase the number of partitions from 100 to 1000

### DIFF
--- a/scripts/hail_batch/increase_snp_chip_partitions/README.md
+++ b/scripts/hail_batch/increase_snp_chip_partitions/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to increase 
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "tob_wgs_snp_chip_pca/increase_partitions/v0" \
+--access-level standard --output-dir "tob_wgs_snp_chip_pca/increase_partitions/v1" \
 --description "increase partitions snp-chip" python3 main.py
 ```

--- a/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
@@ -14,8 +14,8 @@ def query():
     hl.init(default_reference='GRCh38')
 
     snp_chip = hl.read_matrix_table(SNP_CHIP).key_rows_by('locus', 'alleles')
-    snp_chip = snp_chip.repartition(100)
-    snp_chip_path = output_path('snp_chip_100_partitions.mt')
+    snp_chip = snp_chip.repartition(1000)
+    snp_chip_path = output_path('snp_chip_1000_partitions.mt')
     snp_chip.write(snp_chip_path, overwrite=True)
 
 


### PR DESCRIPTION
After previously increasing the number of partitions to 100 in the SNP-Chip dataset, the [subsequent script](https://github.com/populationgenomics/ancestry/blob/main/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py) still failed with an out of memory [error](https://batch.hail.populationgenomics.org.au/batches/3566/jobs/2). Since PCA is sensitive to partitioning, as mentioned [here](https://discuss.hail.is/t/pca-job-aborted-from-sparkexception/1433/46)), this memory issue may be caused by `hwe_normalized_pca` not having enough partitions. I've now increased this to 1000 to see if it solves the issue