### PR TITLE
Update file name to the newly-partitioned mt

### DIFF
--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
@@ -15,7 +15,7 @@ from bokeh.embed import file_html
 from bokeh.io.export import get_screenshot_as_png
 
 SNP_CHIP = bucket_path(
-    'tob_wgs_snp_chip_pca/increase_partitions/v0/snp_chip_100_partitions.mt'
+    'tob_wgs_snp_chip_pca/increase_partitions/v1/snp_chip_1000_partitions.mt'
 )
 TOB_WGS = bucket_path('mt/v3-raw.mt')
 


### PR DESCRIPTION
I've updated the file name to use the SNP-chip matrix table which was repartitioned using 1000 partitions, rather than 100 (as done and described [here](https://github.com/populationgenomics/ancestry/tree/main/scripts/hail_batch/increase_snp_chip_partitions)). 