### PR TITLE
Pca new variants

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/README.md
@@ -1,0 +1,9 @@
+# PCA on TOB-WGS using newly-selected variants
+
+This runs a Hail query script in Dataproc using Hail Batch in order to perform PCA on the densified TOB-WGS matrix table, filtered for variants selected specifically for the combined TOB-WGS + HGDP/1KG datasets (using the same filtering criteria as gnomAD v2.1, however not limited to exonic regions). To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca_new_variants/v0" \
+--description "PCA on new tob variants" python3 main.py
+```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to perform P
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "gs://cpg-tob-wgs-main/1kg_hgdp_densified_pca_new_variants/v0" \
+--access-level standard --output-dir "1kg_hgdp_densified_pca_new_variants/v0" \
 --description "PCA on new tob variants" python3 main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py
@@ -26,8 +26,8 @@ def query():
 
     hl.init(default_reference='GRCh38')
 
-    tob_wgs = hl.read_matrix_table(TOB_WGS)
-    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
+    tob_wgs = hl.read_matrix_table(TOB_WGS).head(10000)
+    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT).head(10000)
 
     # keep loci that are contained in the densified, filtered tob-wgs mt
     hgdp_1kg = hgdp_1kg.semi_join_rows(tob_wgs.rows())

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py
@@ -1,0 +1,65 @@
+"""
+Perform PCA on densified TOB-WGS data. Reliant on output from
+```
+hgdp1kg_tobwgs_densified_pca_new_variants/
+hgdp_1kg_tob_wgs_densified_pca_new_variants.py
+````
+"""
+
+import hail as hl
+import pandas as pd
+from hail.experimental import lgt_to_gt
+from analysis_runner import bucket_path, output_path
+
+
+# TOB_WGS = bucket_path('1kg_hgdp_densify_new_variants/v0/tob_wgs_filtered.mt/')
+TOB_WGS = bucket_path('mt/v4.mt/')
+# TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v4.mt/'
+GNOMAD_HGDP_1KG_MT = (
+    'gs://gcp-public-data--gnomad/release/3.1/mt/genomes/'
+    'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
+)
+
+
+def query():
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    tob_wgs = hl.read_matrix_table(TOB_WGS)
+    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
+
+    # keep loci that are contained in the densified, filtered tob-wgs mt
+    hgdp_1kg = hgdp_1kg.semi_join_rows(tob_wgs.rows())
+
+    # Entries and columns must be identical
+    tob_wgs_select = tob_wgs.select_entries(
+        GT=lgt_to_gt(tob_wgs.LGT, tob_wgs.LA)
+    ).select_cols()
+    hgdp_1kg_select = hgdp_1kg.select_entries(hgdp_1kg.GT).select_cols()
+    # Join datasets
+    hgdp1kg_tobwgs_joined = hgdp_1kg_select.union_cols(tob_wgs_select)
+    # Add in metadata information
+    hgdp_1kg_metadata = hgdp_1kg.cols()
+    hgdp1kg_tobwgs_joined = hgdp1kg_tobwgs_joined.annotate_cols(
+        hgdp_1kg_metadata=hgdp_1kg_metadata[hgdp1kg_tobwgs_joined.s]
+    )
+    # save this for population-level PCAs
+    mt_path = output_path('hgdp1kg_tobwgs_joined_all_samples.mt')
+    if not hl.hadoop_exists(mt_path):
+        hgdp1kg_tobwgs_joined.write(mt_path)
+
+    # Perform PCA
+    eigenvalues_path = output_path('eigenvalues.ht')
+    scores_path = output_path('scores.ht')
+    loadings_path = output_path('loadings.ht')
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(
+        hgdp1kg_tobwgs_joined.GT, compute_loadings=True, k=20
+    )
+    hl.Table.from_pandas(pd.DataFrame(eigenvalues)).export(eigenvalues_path)
+    scores.write(scores_path, overwrite=True)
+    loadings.write(loadings_path, overwrite=True)
+
+
+if __name__ == '__main__':
+    query()

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py
@@ -12,9 +12,7 @@ from hail.experimental import lgt_to_gt
 from analysis_runner import bucket_path, output_path
 
 
-# TOB_WGS = bucket_path('1kg_hgdp_densify_new_variants/v0/tob_wgs_filtered.mt/')
-TOB_WGS = bucket_path('mt/v4.mt/')
-# TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v4.mt/'
+TOB_WGS = bucket_path('1kg_hgdp_densify_new_variants/v0/tob_wgs_filtered.mt/')
 GNOMAD_HGDP_1KG_MT = (
     'gs://gcp-public-data--gnomad/release/3.1/mt/genomes/'
     'gnomad.genomes.v3.1.hgdp_1kg_subset_dense.mt'
@@ -26,8 +24,8 @@ def query():
 
     hl.init(default_reference='GRCh38')
 
-    tob_wgs = hl.read_matrix_table(TOB_WGS).head(10000)
-    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT).head(10000)
+    tob_wgs = hl.read_matrix_table(TOB_WGS)
+    hgdp_1kg = hl.read_matrix_table(GNOMAD_HGDP_1KG_MT)
 
     # keep loci that are contained in the densified, filtered tob-wgs mt
     hgdp_1kg = hgdp_1kg.semi_join_rows(tob_wgs.rows())

--- a/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_densified_pca_new_variants/main.py
@@ -1,0 +1,23 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name=f'tobwgs_pca_new_variants', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    'hgdp_1kg_tob_wgs_densified_pca_new_variants.py',
+    max_age='12h',
+    num_secondary_workers=20,
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    job_name=f'tobwgs_pca_new_variants',
+    worker_boot_disk_size=200,
+)
+
+batch.run()


### PR DESCRIPTION
Perform PCA on newly-selected variants, chosen for the combined TOB-WGS + HGDP/1KG dataset (based off of the same filtering criteria as gnomAD v2.1,but not limited to exonic regions). Since I'm also interested in performing a PCA on NFE samples only, I'm also saving the combined TOB-WGS + HGDP/1KG matrix table, which is a dependency for that analysis. 