### PR TITLE
Add highmem worker machine type

### DIFF
--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/main.py
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/main.py
@@ -16,6 +16,7 @@ dataproc.hail_dataproc_job(
     'project_wgs_samples_onto_snp_chip.py',
     max_age='12h',
     num_secondary_workers=20,
+    worker_machine_type='n1-highmem-8',
     packages=['selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name=f'project_wgs_samples',


### PR DESCRIPTION
After further increasing the SNP-chip dataset to 1000 partitions, it still [failed](https://batch.hail.populationgenomics.org.au/batches/3601/jobs/2) with a memory error. One [suggestion](https://discuss.hail.is/t/pca-job-aborted-from-sparkexception/1433) is using n1-highmem worker nodes instead of n1-standard worker nodes. I've therefore added this as an argument in the `main.py` file within the `hail_dataproc_job` function. 