### PR TITLE
Increase run time and match metadata to samplenames

### DIFF
--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants/main.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants/main.py
@@ -13,7 +13,7 @@ batch = hb.Batch(name='new-variants-plot-pca', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     'plot_pca_and_loadings.py',
-    max_age='1h',
+    max_age='2h',
     packages=['selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name='new-variants-plot-pca',

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants/plot_pca_and_loadings.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants/plot_pca_and_loadings.py
@@ -167,8 +167,13 @@ def query():
             f.write(html)
 
     # plot by continental population
-    metadata = hl.read_matrix_table(HGDP1KG_TOBWGS).hgdp_1kg_metadata
-    labels = metadata.population_inference.pop.collect()
+    hgdp1kg_tobwgs = hl.read_matrix_table(HGDP1KG_TOBWGS)
+    scores = scores.annotate(
+        continental_pop=hgdp1kg_tobwgs.cols()[
+            scores.s
+        ].hgdp_1kg_metadata.population_inference.pop
+    )
+    labels = scores.continental_pop.collect()
     # Change TOB-WGS 'none' values to 'TOB-WGS'
     labels = ['TOB-NFE' if x is None else x for x in labels]
     continental_population = list(set(labels))


### PR DESCRIPTION
My script was nearly finished, but failed after one of the last steps (plotting the loadings, which was half way through). I've now increased the run time from one to two hours, which should be sufficient. I also noticed that my metadata/continental populations were not properly matched to the scores table. I've now matched them using `hgdp1kg_tobwgs.cols()[scores.s].hgdp_1kg_metadata.population_inference.pop`