### PR TITLE
Increase number of partitions to 10k

### DIFF
--- a/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
+++ b/scripts/hail_batch/increase_snp_chip_partitions/increase_snp_chip_partitions.py
@@ -14,8 +14,8 @@ def query():
     hl.init(default_reference='GRCh38')
 
     snp_chip = hl.read_matrix_table(SNP_CHIP).key_rows_by('locus', 'alleles')
-    snp_chip = snp_chip.repartition(1000)
-    snp_chip_path = output_path('snp_chip_1000_partitions.mt')
+    snp_chip = snp_chip.repartition(10000)
+    snp_chip_path = output_path('snp_chip_10000_partitions.mt')
     snp_chip.write(snp_chip_path, overwrite=True)
 
 


### PR DESCRIPTION
After another failed script from `project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py` (which is dependent on the output from this script), I want to try increasing the number of partitions to 10k to more closely mirror the number of partitions from `snp_chip_generate_pca/snp_chip_generate_pca.py`, which runs the same analysis but completed successfully. 