### PR TITLE
Add 20 non-preemptible workers and update snp-chip file

### DIFF
--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/main.py
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/main.py
@@ -15,7 +15,7 @@ dataproc.hail_dataproc_job(
     batch,
     'project_wgs_samples_onto_snp_chip.py',
     max_age='12h',
-    num_secondary_workers=20,
+    num_workers=20,
     worker_machine_type='n1-highmem-8',
     packages=['selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],

--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
@@ -15,7 +15,7 @@ from bokeh.embed import file_html
 from bokeh.io.export import get_screenshot_as_png
 
 SNP_CHIP = bucket_path(
-    'tob_wgs_snp_chip_pca/increase_partitions/v1/snp_chip_1000_partitions.mt'
+    'tob_wgs_snp_chip_pca/increase_partitions/v2/snp_chip_10000_partitions.mt'
 )
 TOB_WGS = bucket_path('mt/v3-raw.mt')
 


### PR DESCRIPTION
Update preemptible workers to non-preemptible workers and add in newly-partitioned snp-chip file, which now has 10k partitions (from `increase_snp_chip_partitions/increase_snp_chip_partitions.py`).