### PR TITLE
Perform PCA on NFE subset, using new variants

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/README.md
@@ -1,0 +1,12 @@
+# Perform pca on pop-specific samples using newly-selected variants
+
+This runs a Hail query script in Dataproc using Hail Batch in order to perform PCA for population subsets on the densified TOB-WGS matrix table, filtered for variants selected specifically for the combined TOB-WGS + HGDP/1KG datasets (using the same filtering criteria as gnomAD v2.1, however not limited to exonic regions). To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+POP=nfe
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "1kg_hgdp_densified_${POP}_new_variants/v0" \
+--description "pca ${POP} densified" python3 main.py ${POP}
+```
+
+Depends on `hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py`.

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/hgdp_1kg_tob_wgs_pop_pca_densified.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/hgdp_1kg_tob_wgs_pop_pca_densified.py
@@ -9,12 +9,12 @@ hgdp_1kg_tob_wgs_densified_pca_new_variants.py
 """
 
 import hail as hl
-import pandas as pd
 import click
-from analysis_runner import bucket_path, output_path
 
-HGDP1KG_TOBWGS = bucket_path(
-    '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
+
+HGDP1KG_TOBWGS = (
+    'gs://cpg-tob-wgs-test/1kg_hgdp_densified_pca_new_variants/'
+    'v0/hgdp1kg_tobwgs_joined_all_samples.mt'
 )
 
 
@@ -36,15 +36,12 @@ def query(pop):
         mt = mt.filter_cols(mt.s.contains('TOB'))
 
     # Perform PCA
-    eigenvalues_path = output_path('eigenvalues.ht')
-    scores_path = output_path('scores.ht')
-    loadings_path = output_path('loadings.ht')
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(
         mt.GT, compute_loadings=True, k=20
     )
-    hl.Table.from_pandas(pd.DataFrame(eigenvalues)).export(eigenvalues_path)
-    scores.write(scores_path, overwrite=True)
-    loadings.write(loadings_path, overwrite=True)
+    print(eigenvalues)
+    print(scores)
+    print(loadings)
 
 
 if __name__ == '__main__':

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/hgdp_1kg_tob_wgs_pop_pca_densified.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/hgdp_1kg_tob_wgs_pop_pca_densified.py
@@ -10,11 +10,12 @@ hgdp_1kg_tob_wgs_densified_pca_new_variants.py
 
 import hail as hl
 import click
+import pandas as pd
+from analysis_runner import bucket_path, output_path
 
 
-HGDP1KG_TOBWGS = (
-    'gs://cpg-tob-wgs-test/1kg_hgdp_densified_pca_new_variants/'
-    'v0/hgdp1kg_tobwgs_joined_all_samples.mt'
+HGDP1KG_TOBWGS = bucket_path(
+    '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
 )
 
 
@@ -36,12 +37,15 @@ def query(pop):
         mt = mt.filter_cols(mt.s.contains('TOB'))
 
     # Perform PCA
+    eigenvalues_path = output_path('eigenvalues.ht')
+    scores_path = output_path('scores.ht')
+    loadings_path = output_path('loadings.ht')
     eigenvalues, scores, loadings = hl.hwe_normalized_pca(
         mt.GT, compute_loadings=True, k=20
     )
-    print(eigenvalues)
-    print(scores)
-    print(loadings)
+    hl.Table.from_pandas(pd.DataFrame(eigenvalues)).export(eigenvalues_path)
+    scores.write(scores_path, overwrite=True)
+    loadings.write(loadings_path, overwrite=True)
 
 
 if __name__ == '__main__':

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/hgdp_1kg_tob_wgs_pop_pca_densified.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/hgdp_1kg_tob_wgs_pop_pca_densified.py
@@ -1,0 +1,51 @@
+"""
+Perform pca on samples specific to a population
+from the HGDP,1KG, and tob-wgs dataset after densifying.
+Reliant on output from
+
+```hgdp1kg_tobwgs_densified_pca_new_variants/
+hgdp_1kg_tob_wgs_densified_pca_new_variants.py
+```
+"""
+
+import hail as hl
+import pandas as pd
+import click
+from analysis_runner import bucket_path, output_path
+
+HGDP1KG_TOBWGS = bucket_path(
+    '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
+)
+
+
+@click.command()
+@click.option('--pop', help='Population to subset from the 1KG (e.g. afr, nfe)')
+def query(pop):
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    mt = hl.read_matrix_table(HGDP1KG_TOBWGS)
+    if pop:
+        # Get samples from the specified population only
+        mt = mt.filter_cols(
+            (mt.hgdp_1kg_metadata.population_inference.pop == pop.lower())
+            | (mt.s.contains('TOB'))
+        )
+    else:
+        mt = mt.filter_cols(mt.s.contains('TOB'))
+
+    # Perform PCA
+    eigenvalues_path = output_path('eigenvalues.ht')
+    scores_path = output_path('scores.ht')
+    loadings_path = output_path('loadings.ht')
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(
+        mt.GT, compute_loadings=True, k=20
+    )
+    hl.Table.from_pandas(pd.DataFrame(eigenvalues)).export(eigenvalues_path)
+    scores.write(scores_path, overwrite=True)
+    loadings.write(loadings_path, overwrite=True)
+
+
+if __name__ == '__main__':
+    query()  # pylint: disable=no-value-for-parameter

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/main.py
@@ -20,6 +20,7 @@ dataproc.hail_dataproc_job(
     max_age='4h',
     num_secondary_workers=20,
     packages=['click'],
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name=f'{POP}-pca-new-variants',
 )
 

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/main.py
@@ -1,0 +1,26 @@
+"""Entry point for the analysis runner."""
+
+import os
+import sys
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+
+POP = sys.argv[1] if len(sys.argv) > 1 else 'nfe'
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name=f'{POP} pca', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'hgdp_1kg_tob_wgs_pop_pca_densified.py --pop {POP}',
+    max_age='4h',
+    num_secondary_workers=20,
+    packages=['click'],
+    job_name=f'{POP}-pca-new-variants',
+)
+
+batch.run()


### PR DESCRIPTION
Perform PCA on TOB-WGS + NFE samples only using the newly-selected variants which were chosen specifically for the combined TOB-WGS + HGDP/1KG datasets.