### PR TITLE
Remove checkpoint for eigenvalues list

### DIFF
--- a/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
+++ b/scripts/hail_batch/project_wgs_onto_snp_chip_pca/project_wgs_samples_onto_snp_chip.py
@@ -39,10 +39,8 @@ def query():  # pylint: disable=too-many-locals
         snp_chip.GT, compute_loadings=True, k=5
     )
 
-    eigenvalues_path = output_path('eigenvalues.ht', 'tmp')
     scores_path = output_path('scores.ht', 'tmp')
     loadings_path = output_path('loadings.ht', 'tmp')
-    eigenvalues = eigenvalues.checkpoint(eigenvalues_path)
     scores = scores.checkpoint(scores_path)
     loadings = loadings.checkpoint(loadings_path)
 


### PR DESCRIPTION
My script failed with the [error](https://batch.hail.populationgenomics.org.au/batches/3755/jobs/2) 
```
eigenvalues = eigenvalues.checkpoint(eigenvalues_path)
AttributeError: 'list' object has no attribute 'checkpoint'
```
so I have removed this checkpoint. Furthermore, checkpointing the `loadings` and `scores` tables already provides information on which stage the script is at.
