### PR TITLE
Increase HDFS space

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_pop_densified_new_variants/main.py
@@ -22,6 +22,7 @@ dataproc.hail_dataproc_job(
     packages=['click'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name=f'{POP}-pca-new-variants',
+    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
My script failed with the [error ](https://batch.hail.populationgenomics.org.au/batches/3753/jobs/2): 

```
RemoteException: File /tmp/write-table-concatenated-g9Xt6exvKdKQqbtVx72sar/_temporary/0/_temporary/attempt_202107280834516532796308026131585_0735_m_000063_19/part-00063 could only be written to 0 of the 1 minReplication nodes. There are 2 datanode(s) running and 2 node(s) are excluded in this operation.
```
Which is likely due to [running out of disk space](https://hail.zulipchat.com/#narrow/stream/123010-Hail-0.2E2.20support/topic/could.20only.20be.20written.20to.200.20of.20the.201.20minReplication.20nodes). 

This was confirmed in the metric explorer:

<img width="880" alt="Screen Shot 2021-07-29 at 12 01 56 pm" src="https://user-images.githubusercontent.com/31531675/127420002-b3f08a6c-5056-4c3c-ac7e-7e46382db661.png">
