### PR TITLE
Generate PCA on NFE samples with outliers removed

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/README.md
@@ -1,0 +1,11 @@
+# Perform pca on nfe samples using newly-selected variants and removing outlier samples
+
+This runs a Hail query script in Dataproc using Hail Batch in order to perform PCA for nfe samples on the densified TOB-WGS matrix table, filtered for variants selected specifically for the combined TOB-WGS + HGDP/1KG datasets (using the same filtering criteria as gnomAD v2.1, however not limited to exonic regions). Two outlier samples, which were generated in `hgdp_1kg_tob_wgs_pop_pca_new_variants_nfe/hgdp_1kg_tob_wgs_plot_pca_nfe.py`, have been removed in order to see more clear clustering between samples. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "1kg_hgdp_densified_nfe_new_variants/v0" \
+--description "pca nfe no outliers" python3 main.py
+```
+
+Depends on `hgdp1kg_tobwgs_densified_pca_new_variants/hgdp_1kg_tob_wgs_densified_pca_new_variants.py`.

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -1,0 +1,48 @@
+"""
+Perform pca on nfe samples from the HGDP/1KG +
+tob-wgs dataset and remove outlier samples.
+Reliant on output from
+
+```hgdp1kg_tobwgs_densified_pca_new_variants/
+hgdp_1kg_tob_wgs_densified_pca_new_variants.py
+```
+"""
+
+import hail as hl
+import pandas as pd
+from analysis_runner import bucket_path, output_path
+
+
+HGDP1KG_TOBWGS = bucket_path(
+    '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
+)
+
+
+def query():
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    mt = hl.read_matrix_table(HGDP1KG_TOBWGS)
+    # Get samples from the specified population only
+    mt = mt.filter_cols(
+        (mt.hgdp_1kg_metadata.population_inference.pop == 'nfe')
+        | (mt.s.contains('TOB'))
+    )
+    # remove outlier samples TOB1734 and TOB1714
+    mt = mt.filter_cols((mt.s != ('TOB1734')) & (mt.s != ('TOB1714')))
+
+    # Perform PCA
+    eigenvalues_path = output_path('eigenvalues.ht')
+    scores_path = output_path('scores.ht')
+    loadings_path = output_path('loadings.ht')
+    eigenvalues, scores, loadings = hl.hwe_normalized_pca(
+        mt.GT, compute_loadings=True, k=20
+    )
+    hl.Table.from_pandas(pd.DataFrame(eigenvalues)).export(eigenvalues_path)
+    scores.write(scores_path, overwrite=True)
+    loadings.write(loadings_path, overwrite=True)
+
+
+if __name__ == '__main__':
+    query()

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -30,7 +30,7 @@ def query():
         | (mt.s.contains('TOB'))
     )
     # remove outlier samples TOB1734 and TOB1714
-    mt = mt.filter_cols((mt.s != ('TOB1734')) & (mt.s != ('TOB1714')))
+    mt = mt.filter_cols((mt.s != 'TOB1734') & (mt.s != 'TOB1714'))
 
     # Perform PCA
     eigenvalues_path = output_path('eigenvalues.ht')

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/main.py
@@ -1,0 +1,23 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name='nfe-pca-no-outliers', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py',
+    max_age='4h',
+    num_secondary_workers=20,
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    job_name=f'nfe-pca-no-outliers',
+    worker_boot_disk_size=200,
+)
+
+batch.run()


### PR DESCRIPTION
This script performs PCA for nfe samples on the densified TOB-WGS matrix table, filtered for variants selected specifically for the combined TOB-WGS + HGDP/1KG datasets. Two outlier samples, which were generated in `hgdp_1kg_tob_wgs_pop_pca_new_variants_nfe/hgdp_1kg_tob_wgs_plot_pca_nfe.py`, have been removed in order to see more clear clustering between samples.