### PR TITLE
Add transparency to glyphs in PCA plot

### DIFF
--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants_nfe_no_outliers/hgdp_1kg_tob_wgs_plot_pca_nfe.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants_nfe_no_outliers/hgdp_1kg_tob_wgs_plot_pca_nfe.py
@@ -17,8 +17,8 @@ from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
 HGDP1KG_TOBWGS = bucket_path(
     '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
 )
-SCORES = bucket_path('1kg_hgdp_densified_nfe_new_variants/v0/scores.ht')
-EIGENVALUES = bucket_path('1kg_hgdp_densified_nfe_new_variants/v0/eigenvalues.ht')
+SCORES = bucket_path('1kg_hgdp_densified_nfe_new_variants/v1/scores.ht')
+EIGENVALUES = bucket_path('1kg_hgdp_densified_nfe_new_variants/v1/eigenvalues.ht')
 
 
 def query():


### PR DESCRIPTION
In my previous PCA plot of NFE samples, it's hard to make out where the TOB-WGS samples are (see https://main-web.populationgenomics.org.au/tob-wgs/tob_wgs_hgdp_1kg_nfe_pca_new_variants/v1/subpopulation_pc1.html). I've therefore increased the alpha/transparency, and also tried rearranging the subpopulations so TOB-WGS is on top. 