### PR TITLE
Remove outlier TOB1126

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -30,7 +30,7 @@ def query():
         | (mt.s.contains('TOB'))
     )
     # remove outlier samples TOB1734 and TOB1714
-    mt = mt.filter_cols((mt.s != 'TOB1734') & (mt.s != 'TOB1714'))
+    mt = mt.filter_cols((mt.s != 'TOB1734') & (mt.s != 'TOB1714') & (mt.s != 'TOB1126'))
 
     # Perform PCA
     eigenvalues_path = output_path('eigenvalues.ht')


### PR DESCRIPTION
Remove outlier TOB1126 to show spread out NFE samples more clearly. We found this sample to be a clear outlier, as shown in the PCA plot here: https://main-web.populationgenomics.org.au/tob-wgs/tob_wgs_hgdp_1kg_nfe_pca_new_variants/v2/study_pc1.html.