### PR TITLE
Remove samples TOB1653 and TOB1668

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -29,8 +29,14 @@ def query():
         (mt.hgdp_1kg_metadata.population_inference.pop == 'nfe')
         | (mt.s.contains('TOB'))
     )
-    # remove outlier samples TOB1734 and TOB1714
-    mt = mt.filter_cols((mt.s != 'TOB1734') & (mt.s != 'TOB1714') & (mt.s != 'TOB1126'))
+    # remove outlier samples
+    mt = mt.filter_cols(
+        (mt.s != 'TOB1734')
+        & (mt.s != 'TOB1714')
+        & (mt.s != 'TOB1126')
+        & (mt.s != 'TOB1653')
+        & (mt.s != 'TOB1668')
+    )
 
     # Perform PCA
     eigenvalues_path = output_path('eigenvalues.ht')


### PR DESCRIPTION
Remove samples TOB1653 and TOB1668, which were found to be outliers in [PC2](https://main-web.populationgenomics.org.au/tob-wgs/tob_wgs_hgdp_1kg_nfe_pca_new_variants/v3/study_pc2.html) and [PC3](https://main-web.populationgenomics.org.au/tob-wgs/tob_wgs_hgdp_1kg_nfe_pca_new_variants/v3/study_pc3.html), respectively. 