### PR TITLE
Remove related samples before performing PCA

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -38,6 +38,16 @@ def query():
         & (mt.s != 'TOB1668')
     )
 
+    # Remove related samples (at the 2nd degree or closer)
+    pc_rel = hl.pc_relate(mt.GT, 0.01, k=20, statistics='kin')
+    pairs = pc_rel.filter(pc_rel['kin'] >= 0.125)
+    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, False)
+    n_related_samples = related_samples_to_remove.count()
+    print(f'related_samples_to_remove.count() = {n_related_samples}')
+    mt = mt.filter_cols(
+        hl.is_defined(related_samples_to_remove[mt.col_key]), keep=False
+    )
+
     # Perform PCA
     eigenvalues_path = output_path('eigenvalues.ht')
     scores_path = output_path('scores.ht')


### PR DESCRIPTION
This script removes related samples from the HGDP/1kG + TOB-WGS matrix table before performing PCA on NFE samples. 