### PR TITLE
Output kinship estimates for related outlier samples in PCA plot

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/README.md
@@ -4,6 +4,6 @@ This runs a Hail query script in Dataproc using Hail Batch in order to estimate 
 
 ```sh
 analysis-runner --dataset tob-wgs \
---access-level standard --output-dir "tob_wgs_hgdp_1kg_nfe_pc_relate_/v0" \
+--access-level standard --output-dir "tob_wgs_hgdp_1kg_nfe_pc_relate/v0" \
 --description "nfe pc_relate" python3 main.py
 ```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/README.md
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/README.md
@@ -1,0 +1,9 @@
+# Run `pc_relate` on nfe samples
+
+This runs a Hail query script in Dataproc using Hail Batch in order to estimate kinship on nfe samples using the `pc_relate` function in Hail. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "tob_wgs_hgdp_1kg_nfe_pc_relate_/v0" \
+--description "nfe pc_relate" python3 main.py
+```

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/hgdp_1kg_tob_wgs_nfe_pc_relate.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/hgdp_1kg_tob_wgs_nfe_pc_relate.py
@@ -1,0 +1,57 @@
+"""
+Estimate kinship for nfe samples from the HGDP/1KG +
+tob-wgs datasets.
+
+"""
+
+import hail as hl
+import pandas as pd
+from analysis_runner import bucket_path, output_path
+
+
+HGDP1KG_TOBWGS = bucket_path(
+    '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
+)
+
+
+def query():
+    """Query script entry point."""
+
+    hl.init(default_reference='GRCh38')
+
+    mt = hl.read_matrix_table(HGDP1KG_TOBWGS)
+    # Get samples from the specified population only
+    mt = mt.filter_cols(
+        (mt.hgdp_1kg_metadata.population_inference.pop == 'nfe')
+        | (mt.s.contains('TOB'))
+    )
+
+    # Perform kinship test with pc_relate
+    pc_rel = hl.pc_relate(mt.GT, 0.01, k=20, statistics='kin')
+    child_pca_outliers = pc_rel.filter(
+        (pc_rel.i.s == 'HG01696') | (pc_rel.i.s == 'HG01629')
+    )
+    # Select parents from the child_pca_outlier matrix
+    child_pca_outliers = child_pca_outliers.filter(
+        (child_pca_outliers.j.s == 'HG01628')
+        | (child_pca_outliers.j.s == 'HG01694')
+        | (child_pca_outliers.j.s == 'HG01695')
+        | (child_pca_outliers.j.s == 'HG01630')
+    )
+
+    # save as html
+    html = pd.DataFrame(
+        {
+            'individual_i': child_pca_outliers.i.s.collect(),
+            'individual_j': child_pca_outliers.j.s.collect(),
+            # this number ranges from 0 to 0.5, with 0.5 being identical
+            'kinship_estimate': child_pca_outliers.kin.collect(),
+        }
+    ).to_html()
+    plot_filename_html = output_path(f'sample_outliers_pc_relate_estimates.html', 'web')
+    with hl.hadoop_open(plot_filename_html, 'w') as f:
+        f.write(html)
+
+
+if __name__ == '__main__':
+    query()

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/hgdp_1kg_tob_wgs_nfe_pc_relate.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/hgdp_1kg_tob_wgs_nfe_pc_relate.py
@@ -27,7 +27,9 @@ def query():
     )
 
     # Perform kinship test with pc_relate
+    pc_rel_path = output_path('pc_relate_kinship_estimate.ht')
     pc_rel = hl.pc_relate(mt.GT, 0.01, k=20, statistics='kin')
+    pc_rel.write(pc_rel_path, overwrite=True)
     child_pca_outliers = pc_rel.filter(
         (pc_rel.i.s == 'HG01696') | (pc_rel.i.s == 'HG01629')
     )

--- a/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/main.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_nfe_pc_relate/main.py
@@ -1,0 +1,23 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name='nfe-pc-relate', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'hgdp_1kg_tob_wgs_nfe_pc_relate.py',
+    max_age='4h',
+    num_secondary_workers=20,
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    job_name=f'nfe-pc-relate',
+    worker_boot_disk_size=200,
+)
+
+batch.run()


### PR DESCRIPTION
I want to investigate the kinship estimates for outlier samples that are known to be related (see [HG01696](https://www.internationalgenome.org/data-portal/sample/HG01696) and [HG01629](https://www.internationalgenome.org/data-portal/sample/HG01629)), as shown by previous[ PCA plots](https://main-web.populationgenomics.org.au/tob-wgs/tob_wgs_hgdp_1kg_nfe_pca_new_variants/v6/subpopulation_pc1.html). It could be that the estimates are just below the threshold, and therefore the minimum relatedness threshold may need to be adjusted. The output from `pc_relate` is a very large dataframe, since it gets the relatedness score for each sample (i) compared to every other sample (j). Therefore, I'm just plotting the output of known outliers for now. 