### PR TITLE
Remove samples which are not included in the gnomAD v3.1 release

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -39,7 +39,7 @@ def query():
     )
 
     # Remove related samples at the 2nd degree or closer, as indicated by gnomAD
-    mt = mt.filter_cols(mt.hgdp_1kg_metadata.gnomad_release is True)
+    mt = mt.filter_cols((mt.hgdp_1kg_metadata.gnomad_release) | (mt.s.contains('TOB')))
 
     # Perform PCA
     eigenvalues_path = output_path('eigenvalues.ht')

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -39,7 +39,7 @@ def query():
     )
 
     # Remove related samples at the 2nd degree or closer, as indicated by gnomAD
-    mt = mt.filter_cols((mt.hgdp_1kg_metadata.gnomad_release) | (mt.s.contains('TOB')))
+    mt = mt.filter_cols(mt.hgdp_1kg_metadata.gnomad_release | mt.s.startswith('TOB'))
 
     # Perform PCA
     eigenvalues_path = output_path('eigenvalues.ht')

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -38,15 +38,8 @@ def query():
         & (mt.s != 'TOB1668')
     )
 
-    # Remove related samples (at the 2nd degree or closer)
-    pc_rel = hl.pc_relate(mt.GT, 0.01, k=20, statistics='kin')
-    pairs = pc_rel.filter(pc_rel['kin'] >= 0.125)
-    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, False)
-    n_related_samples = related_samples_to_remove.count()
-    print(f'related_samples_to_remove.count() = {n_related_samples}')
-    mt = mt.filter_cols(
-        hl.is_defined(related_samples_to_remove[mt.col_key]), keep=False
-    )
+    # Remove related samples at the 2nd degree or closer, as indicated by gnomAD
+    mt = mt.filter_cols(mt.hgdp_1kg_metadata.gnomad_release is True)
 
     # Perform PCA
     eigenvalues_path = output_path('eigenvalues.ht')


### PR DESCRIPTION
After adjusting different parameters in `pc_relate`, I couldn't seem to figure out why two samples---HG01696 and HG01629---are not removed. Digging into why this is happening will be important for future instances using the method, but until then, the metadata table within the HGDP/1kG subset specifies which samples were removed from the gnomAD release due to being related (at the second degree or closer). I've gone ahead and filtered out related samples using this method instead. 