### PR TITLE
Fix manhattan plot loop so that it ierates over all samples

### DIFF
--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/hgdp_1kg_tob_wgs_plot_loadings_nfe_no_outliers.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/hgdp_1kg_tob_wgs_plot_loadings_nfe_no_outliers.py
@@ -120,11 +120,11 @@ def query():  # pylint: disable=too-many-locals
         skip_invalid_contigs=True,
         min_partitions=12,
     )
-    number_of_pcs = hl.len(loadings_ht.loadings).take(1)[0]
+    number_of_pcs = 10
     for i in range(0, (number_of_pcs)):
         pc = i + 1
         p = manhattan_loadings(
-            iteration=1,
+            iteration=i,
             gtf=gtf_ht,
             loadings=loadings_ht,
             title=f'Loadings of PC{pc}',


### PR DESCRIPTION
I had '1' in my loop rather than a variable, so PC1 was plotted each time 🤦‍♀️ I've now updated it 