### PR TITLE
Increase workers

### DIFF
--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/hgdp_1kg_tob_wgs_plot_loadings_nfe_no_outliers.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/hgdp_1kg_tob_wgs_plot_loadings_nfe_no_outliers.py
@@ -181,7 +181,7 @@ def query():  # pylint: disable=too-many-locals
             }
         ).to_html()
         plot_filename_html = output_path(
-            f'significant_variants_non_ref_samples.html', 'web'
+            f'significant_variants_non_ref_samples{dim}.html', 'web'
         )
         with hl.hadoop_open(plot_filename_html, 'w') as f:
             f.write(html)

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/main.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/main.py
@@ -13,7 +13,8 @@ batch = hb.Batch(name='plot-loadings-nfe-no-outliers', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     f'hgdp_1kg_tob_wgs_plot_loadings_nfe_no_outliers.py',
-    max_age='3h',
+    max_age='4h',
+    num_secondary_workers=20,
     packages=['selenium'],
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name=f'plot-loadings-nfe-no-outliers',


### PR DESCRIPTION
The significant_variants output is taking too long to generate without any workers. I've added 20 preemptible/secondary workers, which should speed this up. I've also added in the `hadoop_exists`function so that files that have already been generated do not need to be rerun. 