### PR TITLE
Remove three additional outlier TOB NFE samples, who are ancestry outliers

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -36,6 +36,8 @@ def query():
         & (mt.s != 'TOB1126')
         & (mt.s != 'TOB1653')
         & (mt.s != 'TOB1668')
+        & (mt.s != 'TOB1681')
+        & (mt.s != 'TOB1116')
     )
 
     # Remove related samples at the 2nd degree or closer, as indicated by gnomAD

--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -38,6 +38,7 @@ def query():
         & (mt.s != 'TOB1668')
         & (mt.s != 'TOB1681')
         & (mt.s != 'TOB1116')
+        & (mt.s != 'TOB1107')
     )
 
     # Remove related samples at the 2nd degree or closer, as indicated by gnomAD


### PR DESCRIPTION
From exploring the PCA plots from `hgdp_1kg_tob_wgs_pca_new_variants_nfe_no_outliers/hgdp_1kg_tob_wgs_plot_pca_nfe.py`, it looks like three samples---TOB1681, TOB1116, and TOB1107---are ancestry outliers and driving variation in the first 5 PCs. I've now removed these.