### PR TITLE
Update path to most recent PCA output

### DIFF
--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants_nfe_no_outliers/hgdp_1kg_tob_wgs_plot_pca_nfe.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_new_variants_nfe_no_outliers/hgdp_1kg_tob_wgs_plot_pca_nfe.py
@@ -17,8 +17,8 @@ from bokeh.palettes import turbo  # pylint: disable=no-name-in-module
 HGDP1KG_TOBWGS = bucket_path(
     '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
 )
-SCORES = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v7/scores.ht/')
-EIGENVALUES = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v7/eigenvalues.ht')
+SCORES = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v8/scores.ht/')
+EIGENVALUES = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v8/eigenvalues.ht')
 
 
 def query():

--- a/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/hgdp_1kg_tob_wgs_plot_loadings_nfe_no_outliers.py
+++ b/scripts/plotting/hgdp_1kg_tob_wgs_pca_nfe_loadings_no_outliers/hgdp_1kg_tob_wgs_plot_loadings_nfe_no_outliers.py
@@ -9,9 +9,9 @@ from analysis_runner import bucket_path, output_path
 import hail as hl
 import pandas as pd
 
-LOADINGS = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v7/loadings.ht/')
+LOADINGS = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v8/loadings.ht/')
 GTF_FILE = 'gs://hail-common/references/gencode/gencode.v29.annotation.gtf.bgz'
-SCORES = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v7/scores.ht/')
+SCORES = bucket_path('tob_wgs_hgdp_1kg_nfe_pca_new_variants/v8/scores.ht/')
 HGDP1KG_TOBWGS = bucket_path(
     '1kg_hgdp_densified_pca_new_variants/v0/hgdp1kg_tobwgs_joined_all_samples.mt'
 )
@@ -120,7 +120,7 @@ def query():  # pylint: disable=too-many-locals
         skip_invalid_contigs=True,
         min_partitions=12,
     )
-    number_of_pcs = 10
+    number_of_pcs = hl.len(loadings_ht.loadings).take(1)[0] - 1
     for i in range(0, (number_of_pcs)):
         pc = i + 1
         plot_filename = output_path(f'loadings_manhattan_plot_pc{pc}.png', 'web')


### PR DESCRIPTION
I updated the paths to plot the new PCA output from `hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py`, which removed 8 additional PCA outliers. 