### PR TITLE
Remove 7 additional PCA outliers

### DIFF
--- a/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
+++ b/scripts/hail_batch/hgdp1kg_tobwgs_pca_nfe_new_variants_no_outliers/hgdp_1kg_tob_wgs_nfe_pca_no_outliers.py
@@ -46,7 +46,15 @@ def query():
         'TOB1762',
         'TOB1263',
         'TOB1640',
+        'HG01669',
+        'TOB1795',
+        'TOB1707',
+        'HG01695',
+        'HG01694',
+        'TOB1673',
+        'HG01630',
     ]
+
     mt = mt.filter_cols(hl.literal(outliers).contains(mt.s), keep=False)
 
     # Remove related samples at the 2nd degree or closer, as indicated by gnomAD


### PR DESCRIPTION
As per the results from `hgdp_1kg_tob_wgs_pca_new_variants_nfe_no_outliers/hgdp_1kg_tob_wgs_plot_pca_nfe.py`, 7 additional outliers have been flagged in PCs 3 onwards and removed.