### PR TITLE
Filter table to just related samples

### DIFF
--- a/scripts/plotting/hgdp1kg_tobwgs_pc_relate_unpruned/hgdp_1kg_tob_wgs_related_samples.py
+++ b/scripts/plotting/hgdp1kg_tobwgs_pc_relate_unpruned/hgdp_1kg_tob_wgs_related_samples.py
@@ -9,12 +9,12 @@ from analysis_runner import bucket_path, output_path
 
 
 PC_RELATE_ESTIMATE_NFE = bucket_path(
-    'tob_wgs_hgdp_1kg_nfe_pc_relate/v1/pc_relate_kinship_estimate.ht'
+    'tob_wgs_hgdp_1kg_nfe_pc_relate/v0/pc_relate_kinship_estimate.ht'
 )
 PC_RELATE_ESTIMATE_GLOBAL = bucket_path(
-    'tob_wgs_hgdp_1kg_nfe_pc_relate/v1/pc_relate_kinship_estimate.ht'
+    'tob_wgs_hgdp_1kg_pc_relate/v0/pc_relate_kinship_estimate.ht'
 )
-KING_ESTIMATE_NFE = bucket_path('pc_relate/v3/king_kinship_estimate_global.ht')
+KING_ESTIMATE_NFE = bucket_path('king/v0/king_kinship_estimate_NFE.ht')
 
 
 def query():

--- a/scripts/plotting/hgdp1kg_tobwgs_pc_relate_unpruned/hgdp_1kg_tob_wgs_related_samples.py
+++ b/scripts/plotting/hgdp1kg_tobwgs_pc_relate_unpruned/hgdp_1kg_tob_wgs_related_samples.py
@@ -8,15 +8,13 @@ import pandas as pd
 from analysis_runner import bucket_path, output_path
 
 
-KINSHIP_ESTIMATE_NFE = bucket_path(
-    'tob_wgs_hgdp_1kg_nfe_pc_relate/v0/pc_relate_kinship_estimate.ht'
+PC_RELATE_ESTIMATE_NFE = bucket_path(
+    'tob_wgs_hgdp_1kg_nfe_pc_relate/v1/pc_relate_kinship_estimate.ht'
 )
-
-KINSHIP_ESTIMATE_GLOBAL = bucket_path(
-    'tob_wgs_hgdp_1kg_pc_relate/v0/pc_relate_kinship_estimate.ht'
+PC_RELATE_ESTIMATE_GLOBAL = bucket_path(
+    'tob_wgs_hgdp_1kg_nfe_pc_relate/v1/pc_relate_kinship_estimate.ht'
 )
-
-KING_ESTIMATE_NFE = bucket_path('king/v0/king_kinship_estimate_NFE.ht')
+KING_ESTIMATE_NFE = bucket_path('pc_relate/v3/king_kinship_estimate_global.ht')
 
 
 def query():
@@ -25,34 +23,55 @@ def query():
     hl.init(default_reference='GRCh38')
 
     # save relatedness estimates for pc_relate global populations
-    ht = hl.read_table(KINSHIP_ESTIMATE_GLOBAL)
+    ht = hl.read_table(PC_RELATE_ESTIMATE_GLOBAL)
+    related_samples = ht.filter(ht.kin > 0.1)
     pc_relate_global = pd.DataFrame(
         {
-            'i_s': ht.i.s.collect(),
-            'j_s': ht.j.s.collect(),
-            'kin': ht.kin.collect(),
+            'i_s': related_samples.i.s.collect(),
+            'j_s': related_samples.j.s.collect(),
+            'kin': related_samples.kin.collect(),
         }
     )
     filename = output_path(f'pc_relate_global_matrix.csv', 'metadata')
     pc_relate_global.to_csv(filename, index=False)
 
+    # get maximal independent set
+    pairs = ht.filter(ht['kin'] >= 0.125)
+    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, False)
+
+    related_samples = pd.DataFrame(
+        {'removed_individual': related_samples_to_remove.node.s.collect()}
+    )
+    filename = output_path(f'pc_relate_global_maximal_independent_set.csv', 'metadata')
+    related_samples.to_csv(filename, index=False)
+
     # save relatedness estimates for pc_relate NFE samples
-    ht = hl.read_table(KINSHIP_ESTIMATE_NFE)
+    ht = hl.read_table(PC_RELATE_ESTIMATE_NFE)
+    related_samples = ht.filter(ht.kin > 0.1)
     pc_relate_nfe = pd.DataFrame(
         {
-            'i_s': ht.i.s.collect(),
-            'j_s': ht.j.s.collect(),
-            'kin': ht.kin.collect(),
+            'i_s': related_samples.i.s.collect(),
+            'j_s': related_samples.j.s.collect(),
+            'kin': related_samples.kin.collect(),
         }
     )
     filename = output_path(f'pc_relate_nfe_matrix.csv', 'metadata')
     pc_relate_nfe.to_csv(filename, index=False)
+    # get maximal independent set
+    pairs = ht.filter(ht['kin'] >= 0.125)
+    related_samples_to_remove = hl.maximal_independent_set(pairs.i, pairs.j, False)
+    related_samples = pd.DataFrame(
+        {'removed_individual': related_samples_to_remove.node.s.collect()}
+    )
+    filename = output_path(f'pc_relate_nfe_maximal_independent_set.csv', 'metadata')
+    related_samples.to_csv(filename, index=False)
 
     # save relatedness estimates for KING NFE samples
     mt = hl.read_matrix_table(KING_ESTIMATE_NFE)
     ht = mt.entries()
     # remove entries where samples are identical
     related_samples = ht.filter(ht.s_1 != ht.s)
+    related_samples = ht.filter(ht.phi > 0.1)
     king_nfe = pd.DataFrame(
         {
             'i_s': related_samples.s_1.collect(),
@@ -62,6 +81,24 @@ def query():
     )
     filename = output_path(f'king_nfe_matrix_90k.csv', 'metadata')
     king_nfe.to_csv(filename, index=False)
+    # save KING NFE maximal independent set
+    second_degree_related_samples = ht.filter(
+        (ht.s_1 != ht.s) & (ht.phi > 0.125), keep=True
+    )
+    struct = hl.struct(
+        i=second_degree_related_samples.s_1, j=second_degree_related_samples.s
+    )
+    struct = struct.annotate(phi=second_degree_related_samples.phi)
+    related_samples_to_remove = hl.maximal_independent_set(
+        struct.i, struct.j, False  # pylint: disable=E1101
+    )
+    related_samples = pd.DataFrame(
+        {'related_individual': related_samples_to_remove.node.collect()}
+    )
+    filename = output_path(
+        f'king_90k_related_samples_maximal_independent_set.csv', 'metadata'
+    )
+    related_samples.to_csv(filename, index=False)
 
 
 if __name__ == '__main__':

--- a/scripts/plotting/hgdp1kg_tobwgs_pc_relate_unpruned/hgdp_1kg_tob_wgs_related_samples.py
+++ b/scripts/plotting/hgdp1kg_tobwgs_pc_relate_unpruned/hgdp_1kg_tob_wgs_related_samples.py
@@ -32,7 +32,7 @@ def query():
             'kin': related_samples.kin.collect(),
         }
     )
-    filename = output_path(f'pc_relate_global_matrix.csv', 'metadata')
+    filename = output_path(f'pc_relate_global_matrix.csv', 'analysis')
     pc_relate_global.to_csv(filename, index=False)
 
     # get maximal independent set
@@ -42,7 +42,7 @@ def query():
     related_samples = pd.DataFrame(
         {'removed_individual': related_samples_to_remove.node.s.collect()}
     )
-    filename = output_path(f'pc_relate_global_maximal_independent_set.csv', 'metadata')
+    filename = output_path(f'pc_relate_global_maximal_independent_set.csv', 'analysis')
     related_samples.to_csv(filename, index=False)
 
     # save relatedness estimates for pc_relate NFE samples
@@ -55,7 +55,7 @@ def query():
             'kin': related_samples.kin.collect(),
         }
     )
-    filename = output_path(f'pc_relate_nfe_matrix.csv', 'metadata')
+    filename = output_path(f'pc_relate_nfe_matrix.csv', 'analysis')
     pc_relate_nfe.to_csv(filename, index=False)
     # get maximal independent set
     pairs = ht.filter(ht['kin'] >= 0.125)
@@ -63,7 +63,7 @@ def query():
     related_samples = pd.DataFrame(
         {'removed_individual': related_samples_to_remove.node.s.collect()}
     )
-    filename = output_path(f'pc_relate_nfe_maximal_independent_set.csv', 'metadata')
+    filename = output_path(f'pc_relate_nfe_maximal_independent_set.csv', 'analysis')
     related_samples.to_csv(filename, index=False)
 
     # save relatedness estimates for KING NFE samples
@@ -79,7 +79,7 @@ def query():
             'kin': related_samples.phi.collect(),
         }
     )
-    filename = output_path(f'king_nfe_matrix_90k.csv', 'metadata')
+    filename = output_path(f'king_nfe_matrix_90k.csv', 'analysis')
     king_nfe.to_csv(filename, index=False)
     # save KING NFE maximal independent set
     second_degree_related_samples = ht.filter(
@@ -96,7 +96,7 @@ def query():
         {'related_individual': related_samples_to_remove.node.collect()}
     )
     filename = output_path(
-        f'king_90k_related_samples_maximal_independent_set.csv', 'metadata'
+        f'king_90k_related_samples_maximal_independent_set.csv', 'analysis'
     )
     related_samples.to_csv(filename, index=False)
 


### PR DESCRIPTION
Previously, I exported csv files as all individuals and their relatedness scores, which was far too large. I'm now filtering down to only individuals who are related, which greatly reduces the size of the file.