### PR TITLE
Increase HDFS space

### DIFF
--- a/scripts/hail_batch/export_tob_wgs/main.py
+++ b/scripts/hail_batch/export_tob_wgs/main.py
@@ -13,10 +13,11 @@ batch = hb.Batch(name='export_plink', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     f'export_plink.py',
-    max_age='2h',
+    max_age='4h',
     num_secondary_workers=20,
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name=f'export_plink',
+    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
Although my script finished in `test` on a small subset of the data, it failed this time around with the error `File could only be replicated to 0 nodes instead of 1` (See https://batch.hail.populationgenomics.org.au/batches/5345/jobs/2). Previously, increasing HDFS space has solved this problem, so I've increased `worker_boot_disk_size` to 200.