### PR TITLE
Remove asterisk from command

### DIFF
--- a/scripts/hail_batch/data_transfer/move_tob_wgs_plink.sh
+++ b/scripts/hail_batch/data_transfer/move_tob_wgs_plink.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-gsutil -m -cp -r "gs://cpg-tob-wgs-main/tob_wgs_plink/v0/" "gs://cpg-tob-wgs-shared-jpowell/mt/plink/"
+gsutil -m -cp -r 'gs://cpg-tob-wgs-main/tob_wgs_plink/v0/*' "gs://cpg-tob-wgs-shared-jpowell/mt/plink/"

--- a/scripts/hail_batch/data_transfer/move_tob_wgs_plink.sh
+++ b/scripts/hail_batch/data_transfer/move_tob_wgs_plink.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-gsutil -m -cp -r "gs://cpg-tob-wgs-main/tob_wgs_plink/v0/*" "gs://cpg-tob-wgs-shared-jpowell/mt/plink/"
+gsutil -m -cp -r "gs://cpg-tob-wgs-main/tob_wgs_plink/v0/" "gs://cpg-tob-wgs-shared-jpowell/mt/plink/"


### PR DESCRIPTION
My script [failed](https://batch.hail.populationgenomics.org.au/batches/5448/jobs/1) with the error:
```File "move_tob_wgs_plink.sh", line 5
    gsutil -m -cp -r "gs://cpg-tob-wgs-main/tob_wgs_plink/v0/*" "gs://cpg-tob-wgs-shared-jpowell/mt/plink/"
                                                              ^
SyntaxError: invalid syntax```

I've now removed the asterisk. 