### PR TITLE
Use HAIL_QUERY_BACKEND=local for the job

### DIFF
--- a/scripts/hail_batch/eqtl_hail_batch/generate_eqtl_spearman.py
+++ b/scripts/hail_batch/eqtl_hail_batch/generate_eqtl_spearman.py
@@ -186,6 +186,8 @@ def function_that_merges_dataframes(*df_list):
     return merged_df.to_string()
 
 
+print('HAIL_QUERY_BACKEND=', os.getenv('HAIL_QUERY_BACKEND'))
+
 merge_job = b.new_python_job(name='merge_scatters')
 result_second = merge_job.call(
     function_that_merges_dataframes, *spearman_dfs_from_scatter


### PR DESCRIPTION
This worked for me. 
1. Note `j.env('HAIL_QUERY_BACKEND', 'local')` - I set the variable specifically for this job, because that's the job where `hl.init()` is called. 
2. Note that for temporary files (like spearman_df.csv) I use the local filesystem instead of the bucket (to get around `No FileSystem for scheme "gs"` issue like here https://batch.hail.populationgenomics.org.au/batches/6485/jobs/1)