### PR TITLE
Make scree plot of TOB-WGS data

### DIFF
--- a/scripts/plotting/scree_plot_tob_wgs/README.md
+++ b/scripts/plotting/scree_plot_tob_wgs/README.md
@@ -1,0 +1,9 @@
+# Scree plot of TOB-WGS + NFE samples
+
+This runs a Hail query script in Dataproc using Hail Batch in order to make a scree plot of the TOB-WGS + NFE samples (from HGDP + 1kg dataset), in order to identify the number of PCs to use in the association script LM. This script is dependent on output from `hail_batch/final_tob_batch_pca/generate_pca_no_outliers.py`. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "tob_wgs_hgdp_1kg_nfe/scree/v0" \
+--description "scree plot tob" python3 main.py
+```

--- a/scripts/plotting/scree_plot_tob_wgs/main.py
+++ b/scripts/plotting/scree_plot_tob_wgs/main.py
@@ -1,0 +1,22 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name='tob-wgs-scree', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    'tob_wgs_scree_plot.py',
+    max_age='3h',
+    packages=['selenium'],
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    job_name='tob-wgs-scree',
+)
+
+batch.run()

--- a/scripts/plotting/scree_plot_tob_wgs/tob_wgs_scree_plot.py
+++ b/scripts/plotting/scree_plot_tob_wgs/tob_wgs_scree_plot.py
@@ -1,0 +1,52 @@
+"""
+Make scree plot of TOB-WGS + NFE samples
+(from HGDP + 1kg dataset) in order to identify
+number of PCs to use in LM. Dependent on output from
+`hail_batch/final_tob_batch_pca/generate_pca_no_outliers.py`
+"""
+
+import pandas as pd
+import hail as hl
+from bokeh.resources import CDN
+from bokeh.embed import file_html
+from bokeh.plotting import figure
+from analysis_runner import bucket_path, output_path
+
+EIGENVALUES = bucket_path('kat/pca/nfe_feb22/v0/eigenvalues.ht')
+
+
+def query():  # pylint: disable=too-many-locals
+    """Query script entry point."""
+
+    eigenvalues = pd.read_csv(EIGENVALUES)
+
+    # add in each PC component as a new column
+    eigenvalues['PCs'] = list(eigenvalues.index + 1)
+    # rename '0' column to 'variance'
+    eigenvalues = eigenvalues.rename(columns={eigenvalues.columns[0]: 'variance'})
+    # convert df to strings in order to plot
+    eigenvalues = eigenvalues.applymap(str)
+
+    # plot
+    p = figure(
+        x_range=eigenvalues.PCs,
+        height=500,
+        title='Variance explained',
+        toolbar_location=None,
+        tools='',
+    )
+    p.vbar(x=eigenvalues.PCs, top=eigenvalues.variance, width=0.9)
+    p.xaxis.axis_label = 'PC'
+    p.yaxis.axis_label = 'Percentage of variance explained'
+    p.xgrid.grid_line_color = None
+    p.y_range.start = 0
+    # save plot
+    plot_filename_html = output_path(f'scree_plot_tob_wgs.html', 'web')
+    html = file_html(p, CDN, 'my plot')
+    plot_filename_html = output_path(f'scree_plot.html', 'web')
+    with hl.hadoop_open(plot_filename_html, 'w') as f:
+        f.write(html)
+
+
+if __name__ == '__main__':
+    query()  # pylint: disable=no-value-for-parameter

--- a/scripts/plotting/scree_plot_tob_wgs/tob_wgs_scree_plot.py
+++ b/scripts/plotting/scree_plot_tob_wgs/tob_wgs_scree_plot.py
@@ -12,7 +12,7 @@ from bokeh.embed import file_html
 from bokeh.plotting import figure
 from analysis_runner import bucket_path, output_path
 
-EIGENVALUES = bucket_path('kat/pca/nfe_feb22/v0/eigenvalues.ht')
+EIGENVALUES = bucket_path('kat/pca/nfe/v0/eigenvalues.ht')
 
 
 def query():  # pylint: disable=too-many-locals


### PR DESCRIPTION
Make scree plot of the TOB-WGS + NFE samples (from HGDP + 1kg dataset) in order to identify the number of PCs to use in the association script LM. Output is from `hail_batch/final_tob_batch_pca/generate_pca_no_outliers.py`